### PR TITLE
Use core subscriber instead of relayer

### DIFF
--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -133,7 +133,7 @@ export class NotifyEngine extends INotifyEngine {
     );
 
     // SPEC: Wallet subscribes to response topic
-    await this.client.core.relayer.subscribe(responseTopic);
+    await this.client.core.relayer.subscriber.subscribe(responseTopic);
 
     this.client.logger.info(
       `[Notify] subscribe > subscribed to responseTopic ${responseTopic}`


### PR DESCRIPTION
# Changes
- Use `core.relayer.subscriber.subscribe` instead of `core.relayer.subscribe` which solves issues found in Web3Inbox that cause some subscriptions to fail. 