### PR TITLE
fix(engine): ensure client only sends result for known history

### DIFF
--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -416,7 +416,7 @@ export class NotifyEngine extends INotifyEngine {
     // processes/receives the initial req.
     if (!this.client.core.history.keys.includes(id)) {
       this.client.logger.info(
-        "[Notify] Engine.sendResult > ignoring result for unknown request without history record."
+        `[Notify] Engine.sendResult > ignoring result for unknown request id ${id} without history record on topic ${topic}.`
       );
       return id;
     }

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -411,6 +411,15 @@ export class NotifyEngine extends INotifyEngine {
     result,
     encodeOpts
   ) => {
+    // If the initial request is not in the history, do not attempt to send a result.
+    // E.g. receiving a `wc_notifyMessage` res sent by another client before this client
+    // processes/receives the initial req.
+    if (!this.client.core.history.keys.includes(id)) {
+      this.client.logger.info(
+        "[Notify] Engine.sendResult > ignoring result for unknown request without history record."
+      );
+      return id;
+    }
     const payload = formatJsonRpcResult(id, result);
     const message = await this.client.core.crypto.encode(
       topic,

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -134,7 +134,7 @@ describe("Notify", () => {
         expect(notifyMessageEvent.params.message.body).toBe("Test");
       });
 
-      it.skip("reads the dapp's did.json from memory after the initial fetch", async () => {
+      it("reads the dapp's did.json from memory after the initial fetch", async () => {
         let incomingMessageCount = 0;
         await createNotifySubscription(wallet, account, onSign);
 


### PR DESCRIPTION
## Context

- With multiple clients in play that are subscribed to the same message topic, a given client was exposed a race condition where:
1. Client1 (c1) receives the `wc_notifyMessage` req
2. Client2 (c2) receives the `wc_notifyMessage` req
3. c2 sends `wc_notifyMessage` res first
4. c1 receives the `wc_notifyMessage` res sent by c2 (since message req/res happens on same topic)
5. c1 cleans up the history record based on the res from c2 before it has processed the actual req from step 1

## Solution

* Given we have multiple clients in play on the same subscription, a client should not attempt to respond to a req that it does not have a record for, since this means another client has already done so and it cannot derive the correct response without the request in corresponds to.

## How has this been tested?

- Dogfooded in web3inbox via canary `0.13.1-400699`