### PR TITLE
chore: clean up now unused requests store

### DIFF
--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -31,7 +31,6 @@ export class NotifyClient extends INotifyClient {
   public logger: INotifyClient["logger"];
   public events: INotifyClient["events"] = new EventEmitter();
   public engine: INotifyClient["engine"];
-  public requests: INotifyClient["requests"];
   public subscriptions: INotifyClient["subscriptions"];
   public messages: INotifyClient["messages"];
   public identityKeys: INotifyClient["identityKeys"];
@@ -62,12 +61,6 @@ export class NotifyClient extends INotifyClient {
     this.core = opts.core || new Core(opts);
 
     this.logger = generateChildLogger(logger, this.name);
-    this.requests = new Store(
-      this.core,
-      this.logger,
-      "requests",
-      NOTIFY_CLIENT_STORAGE_PREFIX
-    );
     this.subscriptions = new Store(
       this.core,
       this.logger,
@@ -201,7 +194,6 @@ export class NotifyClient extends INotifyClient {
     this.logger.trace(`Initialized`);
     try {
       await this.core.start();
-      await this.requests.init();
       await this.subscriptions.init();
       await this.messages.init();
       await this.identityKeys.init();

--- a/packages/notify-client/src/constants/engine.ts
+++ b/packages/notify-client/src/constants/engine.ts
@@ -1,9 +1,6 @@
 import { FIVE_MINUTES, THIRTY_DAYS } from "@walletconnect/time";
 import { JsonRpcTypes, RpcOpts } from "../types";
 
-// Expiries
-export const NOTIFY_SUBSCRIPTION_EXPIRY = THIRTY_DAYS;
-
 // JWT-related constants
 export const JWT_SCP_SEPARATOR = " ";
 

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1,8 +1,4 @@
-import {
-  EXPIRER_EVENTS,
-  RELAYER_DEFAULT_PROTOCOL,
-  RELAYER_EVENTS,
-} from "@walletconnect/core";
+import { RELAYER_DEFAULT_PROTOCOL, RELAYER_EVENTS } from "@walletconnect/core";
 import {
   JwtPayload,
   composeDidPkh,
@@ -18,18 +14,12 @@ import {
   isJsonRpcResponse,
   isJsonRpcResult,
 } from "@walletconnect/jsonrpc-utils";
-import {
-  ExpirerTypes,
-  JsonRpcRecord,
-  RelayerTypes,
-} from "@walletconnect/types";
+import { JsonRpcRecord, RelayerTypes } from "@walletconnect/types";
 import {
   TYPE_1,
-  calcExpiry,
   deriveSymKey,
   getInternalError,
   hashKey,
-  parseExpirerTarget,
 } from "@walletconnect/utils";
 import axios from "axios";
 import jwtDecode, { InvalidTokenError } from "jwt-decode";
@@ -57,7 +47,6 @@ export class NotifyEngine extends INotifyEngine {
   public init: INotifyEngine["init"] = () => {
     if (!this.initialized) {
       this.registerRelayerEvents();
-      this.registerExpirerEvents();
       this.client.core.pairing.register({
         methods: Object.keys(ENGINE_RPC_OPTS),
       });
@@ -197,30 +186,6 @@ export class NotifyEngine extends INotifyEngine {
       },
     });
 
-    const scopeMap = this.generateScopeMapFromConfig(notifyConfig.types);
-
-    // Store the pending subscription request.
-    this.client.requests.set(id, {
-      topic: responseTopic,
-      request: {
-        account,
-        metadata: {
-          name: notifyConfig.name,
-          description: notifyConfig.description,
-          icons: notifyConfig.icons,
-          appDomain,
-        },
-        publicKey: selfPublicKey,
-        scope: scopeMap,
-      },
-    });
-
-    // Set the expiry for the notify subscription request.
-    this.client.core.expirer.set(
-      id,
-      calcExpiry(ENGINE_RPC_OPTS["wc_notifySubscribe"].req.ttl)
-    );
-
     return { id, subscriptionAuth };
   };
 
@@ -244,10 +209,6 @@ export class NotifyEngine extends INotifyEngine {
       );
     }
 
-    const identityKeyPub = await this.client.identityKeys.getIdentity({
-      account: subscription.account,
-    });
-
     const updateAuth = await this.generateUpdateAuth({ subscription, scope });
 
     this.client.logger.info(
@@ -264,17 +225,6 @@ export class NotifyEngine extends INotifyEngine {
       id,
       topic,
       updateAuth,
-    });
-
-    await this.client.requests.set(id, {
-      topic,
-      request: {
-        account: subscription.account,
-        metadata: subscription.metadata,
-        publicKey: identityKeyPub,
-        scope: subscription.scope,
-        scopeUpdate: scope,
-      },
     });
 
     return true;
@@ -378,13 +328,6 @@ export class NotifyEngine extends INotifyEngine {
   };
 
   // ---------- Protected Helpers --------------------------------------- //
-
-  protected setExpiry: INotifyEngine["setExpiry"] = async (topic, expiry) => {
-    if (this.client.core.pairing.pairings.keys.includes(topic)) {
-      await this.client.core.pairing.updateExpiry({ topic, expiry });
-    }
-    this.client.core.expirer.set(topic, expiry);
-  };
 
   protected sendRequest: INotifyEngine["sendRequest"] = async (
     topic,
@@ -576,9 +519,6 @@ export class NotifyEngine extends INotifyEngine {
           },
         });
       }
-
-      // Clean up the original request regardless of concrete result.
-      this.cleanupRequest(response.id);
     };
 
   protected onNotifyMessageRequest: INotifyEngine["onNotifyMessageRequest"] =
@@ -803,26 +743,6 @@ export class NotifyEngine extends INotifyEngine {
       }
     };
 
-  // ---------- Expirer Events ---------------------------------------- //
-
-  private registerExpirerEvents() {
-    this.client.core.expirer.on(
-      EXPIRER_EVENTS.expired,
-      async (event: ExpirerTypes.Expiration) => {
-        this.client.logger.info(
-          `[Notify] EXPIRER_EVENTS.expired > target: ${event.target}, expiry: ${event.expiry}`
-        );
-
-        const { id } = parseExpirerTarget(event.target);
-
-        if (id) {
-          await this.cleanupRequest(id, true);
-          this.client.events.emit("request_expire", { id });
-        }
-      }
-    );
-  }
-
   // ---------- Private Helpers --------------------------------- //
 
   private isInitialized() {
@@ -1027,16 +947,6 @@ export class NotifyEngine extends INotifyEngine {
     }
 
     return this.client.subscriptions.getAll();
-  };
-
-  private cleanupRequest = async (id: number, expirerHasDeleted?: boolean) => {
-    await Promise.all([
-      this.client.requests.delete(id, {
-        code: -1,
-        message: "Request deleted.",
-      }),
-      expirerHasDeleted ? Promise.resolve() : this.client.core.expirer.del(id),
-    ]);
   };
 
   private cleanupSubscription = async (topic: string) => {
@@ -1308,6 +1218,8 @@ export class NotifyEngine extends INotifyEngine {
     }
   };
 
+  // @ts-expect-error - keeping this so we can repurpose it later
+  // for watched/changed subscriptions handling.
   private generateScopeMapFromConfig = (
     typesConfig: NotifyClientTypes.NotifyConfigDocument["types"],
     selected?: string[]

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -64,14 +64,6 @@ export declare namespace NotifyClientTypes {
 
   type ScopeMap = Record<string, { description: string; enabled: boolean }>;
 
-  interface NotifySubscriptionRequest {
-    publicKey: string;
-    metadata: Metadata;
-    account: string;
-    scope: ScopeMap;
-    scopeUpdate?: string[];
-  }
-
   interface NotifySubscription {
     topic: string;
     account: string;
@@ -240,13 +232,6 @@ export abstract class INotifyClient {
   public abstract logger: Logger;
   public abstract engine: INotifyEngine;
 
-  public abstract requests: IStore<
-    number,
-    {
-      topic: string;
-      request: NotifyClientTypes.NotifySubscriptionRequest;
-    }
-  >;
   public abstract messages: IStore<
     string,
     {

--- a/packages/notify-client/src/types/engine.ts
+++ b/packages/notify-client/src/types/engine.ts
@@ -92,8 +92,6 @@ export abstract class INotifyEngine {
     opts?: CryptoTypes.EncodeOptions
   ): Promise<number>;
 
-  protected abstract setExpiry(topic: string, expiry: number): Promise<void>;
-
   // ---------- Protected Relay Event Methods ----------------------------------- //
 
   protected abstract onRelayEventRequest(

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -63,7 +63,6 @@ describe("Notify", () => {
       expect(wallet.core).toBeDefined();
       expect(wallet.events).toBeDefined();
       expect(wallet.logger).toBeDefined();
-      expect(wallet.requests).toBeDefined();
       expect(wallet.subscriptions).toBeDefined();
       expect(wallet.core.expirer).toBeDefined();
       expect(wallet.core.history).toBeDefined();


### PR DESCRIPTION
## Context

- We no longer need the `requests` store, since NotifyServer is now the source of truth for subscriptions, rather than client-to-client.
- `requests` was being set but no longer read as `notify_subscription` response no longer returns partial subscription information that needs to be hydrated to form the full subscription the client can store.
- Since subscriptions do not currently expire, we can also remove the expirer related helper code and listener setup. If we encounter a need for expiries on the NotifyClient level again at a later point we should add this fresh.
- Additionally:
    - Repurposes and simplifies `generateScopeMap` helper for its current usage in `updateSubscriptionsWithJwt`

## How has this been tested?

- Integ tests
- Ensured `generateScopeMap` yields the same results as the prev inlined code was.