### PR TITLE
Chore/watch subs default

### DIFF
--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -79,7 +79,8 @@ export class NotifyClient extends INotifyClient {
       this.core,
       this.logger,
       "lastWatchedAccount",
-      NOTIFY_CLIENT_STORAGE_PREFIX
+      NOTIFY_CLIENT_STORAGE_PREFIX,
+      () => "lastWatched"
     );
 
     this.identityKeys =

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -207,9 +207,7 @@ export class NotifyClient extends INotifyClient {
       await this.subscriptions.init();
       await this.messages.init();
       await this.identityKeys.init();
-
       await this.lastWatchedAccount.init();
-
       await this.engine.init();
 
       this.logger.info(`NotifyClient Initialization Success`);

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -18,7 +18,6 @@ import {
 } from "./constants";
 import { NotifyEngine } from "./controllers";
 import { INotifyClient, NotifyClientTypes } from "./types";
-import { IStore } from "@walletconnect/types";
 
 export class NotifyClient extends INotifyClient {
   public readonly protocol = NOTIFY_CLIENT_PROTOCOL;

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -18,6 +18,7 @@ import {
 } from "./constants";
 import { NotifyEngine } from "./controllers";
 import { INotifyClient, NotifyClientTypes } from "./types";
+import { IStore } from "@walletconnect/types";
 
 export class NotifyClient extends INotifyClient {
   public readonly protocol = NOTIFY_CLIENT_PROTOCOL;
@@ -33,6 +34,7 @@ export class NotifyClient extends INotifyClient {
   public engine: INotifyClient["engine"];
   public subscriptions: INotifyClient["subscriptions"];
   public messages: INotifyClient["messages"];
+  public lastWatchedAccount: INotifyClient["lastWatchedAccount"];
   public identityKeys: INotifyClient["identityKeys"];
 
   static async init(opts: NotifyClientTypes.ClientOptions) {
@@ -73,6 +75,14 @@ export class NotifyClient extends INotifyClient {
       "messages",
       NOTIFY_CLIENT_STORAGE_PREFIX
     );
+
+    this.lastWatchedAccount = new Store(
+      this.core,
+      this.logger,
+      "lastWatchedAccount",
+      NOTIFY_CLIENT_STORAGE_PREFIX
+    );
+
     this.identityKeys =
       opts.identityKeys ?? new IdentityKeys(this.core, this.keyserverUrl);
     this.engine = new NotifyEngine(this);
@@ -197,7 +207,10 @@ export class NotifyClient extends INotifyClient {
       await this.subscriptions.init();
       await this.messages.init();
       await this.identityKeys.init();
-      this.engine.init();
+
+      await this.lastWatchedAccount.init();
+
+      await this.engine.init();
 
       this.logger.info(`NotifyClient Initialization Success`);
     } catch (error: any) {

--- a/packages/notify-client/src/constants/clients.ts
+++ b/packages/notify-client/src/constants/clients.ts
@@ -8,3 +8,5 @@ export const NOTIFY_CLIENT_STORAGE_PREFIX = `${NOTIFY_CLIENT_PROTOCOL}@${NOTIFY_
 export const DEFAULT_NOTIFY_SERVER_URL = "https://notify.walletconnect.com";
 export const DEFAULT_RELAY_SERVER_URL = "wss://relay.walletconnect.com";
 export const DEFAULT_KEYSERVER_URL = "https://keys.walletconnect.com";
+
+export const LAST_WATCHED_KEY = "lastWatched";

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -28,6 +28,7 @@ import {
   DID_WEB_PREFIX,
   ENGINE_RPC_OPTS,
   JWT_SCP_SEPARATOR,
+  LAST_WATCHED_KEY,
   LIMITED_IDENTITY_STATEMENT,
   UNLIMITED_IDENTITY_STATEMENT,
 } from "../constants";
@@ -820,8 +821,8 @@ export class NotifyEngine extends INotifyEngine {
       }
     );
 
-    this.client.lastWatchedAccount.set("lastWatched", {
-      lastWatched: accountId,
+    this.client.lastWatchedAccount.set(LAST_WATCHED_KEY, {
+      [LAST_WATCHED_KEY]: accountId,
     });
 
     this.client.logger.info("watchSubscriptions >", "requestId >", id);
@@ -1224,7 +1225,7 @@ export class NotifyEngine extends INotifyEngine {
     // If an account was previously watched
     if (this.client.lastWatchedAccount.keys.length === 1) {
       const { lastWatched: account } =
-        this.client.lastWatchedAccount.get("lastWatched");
+        this.client.lastWatchedAccount.get(LAST_WATCHED_KEY);
 
       try {
         // Account for invalid state where the last watched account does not have an identity.

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -44,12 +44,18 @@ export class NotifyEngine extends INotifyEngine {
     super(client);
   }
 
-  public init: INotifyEngine["init"] = () => {
+  public init: INotifyEngine["init"] = async () => {
     if (!this.initialized) {
       this.registerRelayerEvents();
       this.client.core.pairing.register({
         methods: Object.keys(ENGINE_RPC_OPTS),
       });
+
+      if (this.client.lastWatchedAccount.keys.length === 1) {
+        await this.watchSubscriptions(
+          this.client.lastWatchedAccount.get("lastWatched").lastWatched
+        );
+      }
 
       this.initialized = true;
     }
@@ -817,6 +823,10 @@ export class NotifyEngine extends INotifyEngine {
         receiverPublicKey: notifyKeys.dappPublicKey,
       }
     );
+
+    this.client.lastWatchedAccount.set("lastWatched", {
+      lastWatched: accountId,
+    });
 
     this.client.logger.info("watchSubscriptions >", "requestId >", id);
   }

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1231,8 +1231,11 @@ export class NotifyEngine extends INotifyEngine {
         const identity = await this.client.identityKeys.getIdentity({
           account,
         });
-        if (!identity)
-          throw new Error(`No identity key found for lastWatchedAccount ${account}`);
+        if (!identity) {
+          throw new Error(
+            `No identity key found for lastWatchedAccount ${account}`
+          );
+        }
       } catch (error) {
         this.client.logger.error(
           `[Notify] Engine > watchLastWatchedAccountIfExists failed: ${error}`

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1232,7 +1232,7 @@ export class NotifyEngine extends INotifyEngine {
           account,
         });
         if (!identity)
-          throw new Error("No identity key for lastWatchedAccount");
+          throw new Error(`No identity key found for lastWatchedAccount ${account}`);
       } catch (error) {
         this.client.logger.error(
           `[Notify] Engine > watchLastWatchedAccountIfExists failed: ${error}`

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -51,7 +51,7 @@ export class NotifyEngine extends INotifyEngine {
         methods: Object.keys(ENGINE_RPC_OPTS),
       });
 
-      await this.watchLastWatchedAccount();
+      await this.watchLastWatchedAccountIfExists();
 
       this.initialized = true;
     }
@@ -1220,7 +1220,8 @@ export class NotifyEngine extends INotifyEngine {
     );
   };
 
-  private watchLastWatchedAccount = async () => {
+  private watchLastWatchedAccountIfExists = async () => {
+    // If an account was previously watched
     if (this.client.lastWatchedAccount.keys.length === 1) {
       const { lastWatched: account } =
         this.client.lastWatchedAccount.get("lastWatched");

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1235,7 +1235,7 @@ export class NotifyEngine extends INotifyEngine {
           throw new Error("No identity key for lastWatchedAccount");
       } catch (error) {
         this.client.logger.error(
-          `[Notify] Last watched account ${account} has no registered identity. Can not watch subscriptions by default. `
+          `[Notify] Engine > watchLastWatchedAccountIfExists failed: ${error}`
         );
         return;
       }

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1244,7 +1244,7 @@ export class NotifyEngine extends INotifyEngine {
         await this.watchSubscriptions(account);
       } catch (error: any) {
         this.client.logger.error(
-          `[Notify] Failed to watch subscriptions for account ${account} > ${error.message}`
+          `[Notify] Engine.watchLastWatchedAccountIfExists > Failed to watch subscriptions for account ${account} > ${error.message}`
         );
       }
     }

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -3,6 +3,7 @@ import { ErrorResponse } from "@walletconnect/jsonrpc-utils";
 import { CoreTypes, ICore, IStore, RelayerTypes } from "@walletconnect/types";
 import EventEmitter from "events";
 import { Logger } from "pino";
+import { LAST_WATCHED_KEY } from "../constants";
 
 import { INotifyEngine } from "./engine";
 
@@ -241,9 +242,9 @@ export abstract class INotifyClient {
   >;
 
   public abstract lastWatchedAccount: IStore<
-    "lastWatched",
+    typeof LAST_WATCHED_KEY,
     {
-      lastWatched: string;
+      [LAST_WATCHED_KEY]: string;
     }
   >;
   public abstract identityKeys: IdentityKeys;

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -239,6 +239,13 @@ export abstract class INotifyClient {
       messages: Record<number, NotifyClientTypes.NotifyMessageRecord>;
     }
   >;
+
+  public abstract lastWatchedAccount: IStore<
+    "lastWatched",
+    {
+      lastWatched: string;
+    }
+  >;
   public abstract identityKeys: IdentityKeys;
 
   public abstract subscriptions: IStore<

--- a/packages/notify-client/src/types/engine.ts
+++ b/packages/notify-client/src/types/engine.ts
@@ -25,7 +25,7 @@ export declare namespace NotifyEngineTypes {
 export abstract class INotifyEngine {
   constructor(public client: INotifyClient) {}
 
-  public abstract init(): void;
+  public abstract init(): Promise<void>;
 
   // ---------- Public Methods ------------------------------------------ //
 

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -136,6 +136,11 @@ describe("Notify", () => {
 
       it("reads the dapp's did.json from memory after the initial fetch", async () => {
         let incomingMessageCount = 0;
+        // 2 Fetch calls happen on auto-init.
+        // Since this is using an already established core and registered identity
+        // watch subscriptions will be called on init, causing 2 calls to occur.
+        const AUTO_WATCH_SUB_FETCH_ACCOUNT = 2;
+
         await createNotifySubscription(wallet, account, onSign);
 
         wallet = await NotifyClient.init({
@@ -159,7 +164,10 @@ describe("Notify", () => {
         await waitForEvent(() => incomingMessageCount === 2);
 
         // Ensure `axios.get` was only called once to resolve the dapp's did.json
-        expect(axiosSpy).toHaveBeenCalledTimes(1);
+        // We have to account for the initial calls that happened during watchSubscriptions on init
+        expect(axiosSpy).toHaveBeenCalledTimes(
+          1 + AUTO_WATCH_SUB_FETCH_ACCOUNT
+        );
       });
     });
 

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -451,7 +451,7 @@ describe("Notify", () => {
         expect(updateEvent.topic).toBe(subscriptions[0].topic);
       });
 
-      it("automatically fires watchSubscriptions", async () => {
+      it("automatically fires watchSubscriptions on init", async () => {
         const storageLoc = generateClientDbName("notifyTest");
         const wallet1 = await NotifyClient.init({
           name: "testNotifyClient1",

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -136,47 +136,47 @@ describe("Notify", () => {
 
       it("reads the dapp's did.json from memory after the initial fetch", async () => {
         let incomingMessageCount = 0;
-	// These are calls that occur due to registering.
-	// 1 - NOTIFY_SERVER_URL/.well-known/did.json
-	// 2 - GM_DAPP/.well-known/did.json
-	// 3 - GM_DAPP/.well-known/wc-notify-config.json
+        // These are calls that occur due to registering.
+        // 1 - NOTIFY_SERVER_URL/.well-known/did.json
+        // 2 - GM_DAPP/.well-known/did.json
+        // 3 - GM_DAPP/.well-known/wc-notify-config.json
         const INITIAL_CALLS_FETCH_ACCOUNT = 3;
         const axiosSpy = vi.spyOn(axios, "get");
 
-	const ethersWallet2 = EthersWallet.createRandom();
-	const account2 = `eip155:1:${ethersWallet2.address}`;
+        const ethersWallet2 = EthersWallet.createRandom();
+        const account2 = `eip155:1:${ethersWallet2.address}`;
         const storageLoc = generateClientDbName("notifyTestDidJson");
-	
 
         const wallet1 = await NotifyClient.init({
           name: "testNotifyClient2",
           logger: "error",
           keyserverUrl: DEFAULT_KEYSERVER_URL,
           relayUrl: DEFAULT_RELAY_URL,
-          core: new Core({projectId, storageOptions: {database: storageLoc}}),
+          core: new Core({
+            projectId,
+            storageOptions: { database: storageLoc },
+          }),
           projectId,
         });
 
-
-        await createNotifySubscription(wallet1, account2, (m) => ethersWallet2.signMessage(m));
+        await createNotifySubscription(wallet1, account2, (m) =>
+          ethersWallet2.signMessage(m)
+        );
 
         wallet1.on("notify_message", (event) => {
           incomingMessageCount += 1;
         });
 
-	
         await sendNotifyMessage(account2, "Test");
         await sendNotifyMessage(account2, "Test");
 
         await waitForEvent(() => {
-	  return incomingMessageCount === 2
-	});
+          return incomingMessageCount === 2;
+        });
 
         // Ensure `axios.get` was only called once to resolve the dapp's did.json
         // We have to account for the initial calls that happened during watchSubscriptions on init
-        expect(axiosSpy).toHaveBeenCalledTimes(
-          1 + INITIAL_CALLS_FETCH_ACCOUNT
-        );
+        expect(axiosSpy).toHaveBeenCalledTimes(1 + INITIAL_CALLS_FETCH_ACCOUNT);
       });
     });
 

--- a/packages/notify-client/test/helpers/storage.ts
+++ b/packages/notify-client/test/helpers/storage.ts
@@ -1,0 +1,4 @@
+import { generateRandomBytes32 } from "@walletconnect/utils";
+
+export const generateClientDbName = (prefix: string) =>
+  `./test/tmp/${prefix}_${generateRandomBytes32()}.db`;


### PR DESCRIPTION
Resolves #55 

- Adds `lastWatchedAccount` store  that should only ever store no values or 1 value (which would be the last watched account)
- Once an account is watched, it is registered as the lastWatchedAccount
- On every init, the last watched account is checked. If one exists and it has a valid identity key, attempt to watch for it.
- Account for this change in the did.json cache unit test since there will be 2 new calls 1 occurring from `watchSubscriptions` and the other occurring from handling the response.