### PR TITLE
chore: bump notify to 0.13.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6108,7 +6108,7 @@
     },
     "packages/notify-client": {
       "name": "@walletconnect/notify-client",
-      "version": "0.13.3",
+      "version": "0.13.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^1.7.3",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/notify-client",
   "description": "WalletConnect Notify Client",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/notify-client-js/",
   "license": "Apache-2.0",


### PR DESCRIPTION
Bump notify to `0.13.4`. 

Once this PR is approved, it'll be tagged, a release will be made and then published to NPM.

This mainly adds changes from #55.

The docs never mentioned how watchSubscriptions worked so there is no need for an urgent docs change since now it behaves as expected. 