### PR TITLE
Chore/check for prev statement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1689,9 +1689,9 @@
       }
     },
     "node_modules/@walletconnect/identity-keys": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@walletconnect/identity-keys/-/identity-keys-0.2.1.tgz",
-      "integrity": "sha512-2Z1eYDKTxf7RavXhCbPL32BZtw97AIp3TjYRIIZVgE2sPTjTPbmPHrNideeE9szVXLIA2dPtpo30WBtwRdSAcQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@walletconnect/identity-keys/-/identity-keys-0.2.2.tgz",
+      "integrity": "sha512-Od34t90Z+fFV3akTapgUbn+NlsgJEBRQ0dIckgT3VMWtQZ0kj3PXYIJL1YOmfpBMiU1n5VVGTkqgIRxMxWiWdg==",
       "dependencies": {
         "@noble/ed25519": "^1.7.1",
         "@walletconnect/cacao": "1.0.2",
@@ -6139,7 +6139,7 @@
         "@walletconnect/cacao": "1.0.2",
         "@walletconnect/core": "^2.10.1",
         "@walletconnect/did-jwt": "2.0.1",
-        "@walletconnect/identity-keys": "^0.2.1",
+        "@walletconnect/identity-keys": "^0.2.2",
         "@walletconnect/jsonrpc-utils": "1.0.7",
         "@walletconnect/time": "1.0.2",
         "@walletconnect/utils": "^2.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1688,6 +1688,30 @@
         "tslib": "1.14.1"
       }
     },
+    "node_modules/@walletconnect/identity-keys": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/identity-keys/-/identity-keys-0.2.1.tgz",
+      "integrity": "sha512-2Z1eYDKTxf7RavXhCbPL32BZtw97AIp3TjYRIIZVgE2sPTjTPbmPHrNideeE9szVXLIA2dPtpo30WBtwRdSAcQ==",
+      "dependencies": {
+        "@noble/ed25519": "^1.7.1",
+        "@walletconnect/cacao": "1.0.2",
+        "@walletconnect/core": "^2.10.1",
+        "@walletconnect/did-jwt": "2.0.3",
+        "@walletconnect/types": "^2.10.1",
+        "@walletconnect/utils": "^2.10.1",
+        "axios": "^1.3.5"
+      }
+    },
+    "node_modules/@walletconnect/identity-keys/node_modules/@walletconnect/did-jwt": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/did-jwt/-/did-jwt-2.0.3.tgz",
+      "integrity": "sha512-maWNR0uzbzqsN0Fknorq/be5NXIAg0e32ILLl5EQE48WhAxK7bTzwqceI2Biq0cgI9knr3G2A9CGBJ9mUPa4kA==",
+      "dependencies": {
+        "@noble/ed25519": "1.7.3",
+        "bs58": "5.0.0",
+        "multiformats": "^9.9.0"
+      }
+    },
     "node_modules/@walletconnect/jsonrpc-provider": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/@walletconnect/jsonrpc-provider/-/jsonrpc-provider-1.0.13.tgz",
@@ -6115,7 +6139,7 @@
         "@walletconnect/cacao": "1.0.2",
         "@walletconnect/core": "^2.10.1",
         "@walletconnect/did-jwt": "2.0.1",
-        "@walletconnect/identity-keys": "^0.2.0",
+        "@walletconnect/identity-keys": "^0.2.1",
         "@walletconnect/jsonrpc-utils": "1.0.7",
         "@walletconnect/time": "1.0.2",
         "@walletconnect/utils": "^2.10.1",
@@ -6127,30 +6151,6 @@
         "@types/lodash.clonedeep": "^4.5.7",
         "@walletconnect/types": "^2.10.1",
         "lodash.clonedeep": "^4.5.0"
-      }
-    },
-    "packages/notify-client/node_modules/@walletconnect/identity-keys": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/identity-keys/-/identity-keys-0.2.0.tgz",
-      "integrity": "sha512-PwFLESTRMuC3nvxDxFWQ83nijx2YnJ5/A+yRwhD01sYDMzBHYC4qKKd+6Srv6l/ffQqn6Mw43xiTKmI6a66P7Q==",
-      "dependencies": {
-        "@noble/ed25519": "^1.7.1",
-        "@walletconnect/cacao": "1.0.2",
-        "@walletconnect/core": "^2.10.1",
-        "@walletconnect/did-jwt": "2.0.3",
-        "@walletconnect/types": "^2.10.1",
-        "@walletconnect/utils": "^2.10.1",
-        "axios": "^1.3.5"
-      }
-    },
-    "packages/notify-client/node_modules/@walletconnect/identity-keys/node_modules/@walletconnect/did-jwt": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/did-jwt/-/did-jwt-2.0.3.tgz",
-      "integrity": "sha512-maWNR0uzbzqsN0Fknorq/be5NXIAg0e32ILLl5EQE48WhAxK7bTzwqceI2Biq0cgI9knr3G2A9CGBJ9mUPa4kA==",
-      "dependencies": {
-        "@noble/ed25519": "1.7.3",
-        "bs58": "5.0.0",
-        "multiformats": "^9.9.0"
       }
     }
   }

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -34,7 +34,7 @@
     "@walletconnect/cacao": "1.0.2",
     "@walletconnect/core": "^2.10.1",
     "@walletconnect/did-jwt": "2.0.1",
-    "@walletconnect/identity-keys": "^0.2.0",
+    "@walletconnect/identity-keys": "^0.2.1",
     "@walletconnect/jsonrpc-utils": "1.0.7",
     "@walletconnect/time": "1.0.2",
     "@walletconnect/utils": "^2.10.1",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -34,7 +34,7 @@
     "@walletconnect/cacao": "1.0.2",
     "@walletconnect/core": "^2.10.1",
     "@walletconnect/did-jwt": "2.0.1",
-    "@walletconnect/identity-keys": "^0.2.1",
+    "@walletconnect/identity-keys": "^0.2.2",
     "@walletconnect/jsonrpc-utils": "1.0.7",
     "@walletconnect/time": "1.0.2",
     "@walletconnect/utils": "^2.10.1",

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -69,8 +69,7 @@ export class NotifyClient extends INotifyClient {
       this.logger,
       "signedStatements",
       NOTIFY_CLIENT_STORAGE_PREFIX,
-      ({account}: {account: string}) => account
-
+      ({ account }: { account: string }) => account
     );
 
     this.subscriptions = new Store(

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -216,6 +216,7 @@ export class NotifyClient extends INotifyClient {
       await this.core.start();
       await this.subscriptions.init();
       await this.messages.init();
+      await this.signedStatements.init();
       await this.identityKeys.init();
       await this.lastWatchedAccount.init();
       await this.engine.init();

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -62,14 +62,15 @@ export class NotifyClient extends INotifyClient {
     this.notifyServerUrl = DEFAULT_NOTIFY_SERVER_URL;
     this.core = opts.core || new Core(opts);
 
-
     this.logger = generateChildLogger(logger, this.name);
 
     this.signedStatements = new Store(
       this.core,
       this.logger,
       "signedStatements",
-      NOTIFY_CLIENT_STORAGE_PREFIX
+      NOTIFY_CLIENT_STORAGE_PREFIX,
+      ({account}: {account: string}) => account
+
     );
 
     this.subscriptions = new Store(

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -34,6 +34,7 @@ export class NotifyClient extends INotifyClient {
   public subscriptions: INotifyClient["subscriptions"];
   public messages: INotifyClient["messages"];
   public lastWatchedAccount: INotifyClient["lastWatchedAccount"];
+  public signedStatements: INotifyClient["signedStatements"];
   public identityKeys: INotifyClient["identityKeys"];
 
   static async init(opts: NotifyClientTypes.ClientOptions) {
@@ -61,7 +62,16 @@ export class NotifyClient extends INotifyClient {
     this.notifyServerUrl = DEFAULT_NOTIFY_SERVER_URL;
     this.core = opts.core || new Core(opts);
 
+
     this.logger = generateChildLogger(logger, this.name);
+
+    this.signedStatements = new Store(
+      this.core,
+      this.logger,
+      "signedStatements",
+      NOTIFY_CLIENT_STORAGE_PREFIX
+    );
+
     this.subscriptions = new Store(
       this.core,
       this.logger,

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1115,12 +1115,10 @@ export class NotifyEngine extends INotifyEngine {
           statement
         )
       ) {
-	console.log("statement is stale.")
         try {
           await this.client.identityKeys.unregisterIdentity({
             account: accountId,
           });
-	  console.log("removed identity key")
         } catch {
           throw new Error(
             `Failed to unregister ${accountId} which has a stale signature`
@@ -1262,11 +1260,7 @@ export class NotifyEngine extends INotifyEngine {
 
     const signedStatement = this.client.signedStatements.get(account);
 
-    if (signedStatement.statement !== currentStatement) {
-      return true;
-    }
-
-    return false;
+    return signedStatement.statement !== currentStatement
   };
 
   private watchLastWatchedAccountIfExists = async () => {

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1109,12 +1109,7 @@ export class NotifyEngine extends INotifyEngine {
     domain: string
   ): Promise<string> => {
     if (await this.client.identityKeys.hasIdentity({ account: accountId })) {
-      if (
-        this.checkIfSignedStatementIsStale(
-          accountId,
-          statement
-        )
-      ) {
+      if (this.checkIfSignedStatementIsStale(accountId, statement)) {
         try {
           await this.client.identityKeys.unregisterIdentity({
             account: accountId,
@@ -1260,7 +1255,7 @@ export class NotifyEngine extends INotifyEngine {
 
     const signedStatement = this.client.signedStatements.get(account);
 
-    return signedStatement.statement !== currentStatement
+    return signedStatement.statement !== currentStatement;
   };
 
   private watchLastWatchedAccountIfExists = async () => {

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1218,6 +1218,25 @@ export class NotifyEngine extends INotifyEngine {
     );
   };
 
+  // returns true if statement is stale, false otherwise.
+  private checkIfSignedStatementIsStale = (account: string, currentStatement: string) => {
+    const hasSignedStatement = this.client.signedStatements.keys.includes(account);
+    if(!hasSignedStatement) {
+      // if there is no signed statement, then this account's statement was signed
+      // previous to this function (and thus the latest statement) being introduced
+      // therefore, it is stale.
+      return true;
+    }
+
+    const signedStatement = this.client.signedStatements.get(account);
+
+    if(signedStatement.statement !== currentStatement) {
+      return true;
+    }
+
+    return false;
+  }
+
   private watchLastWatchedAccountIfExists = async () => {
     // If an account was previously watched
     if (this.client.lastWatchedAccount.keys.length === 1) {

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1112,13 +1112,15 @@ export class NotifyEngine extends INotifyEngine {
       if (
         this.checkIfSignedStatementIsStale(
           accountId,
-          NOTIFY_AUTHORIZATION_STATEMENT
+          statement
         )
       ) {
+	console.log("statement is stale.")
         try {
           await this.client.identityKeys.unregisterIdentity({
             account: accountId,
           });
+	  console.log("removed identity key")
         } catch {
           throw new Error(
             `Failed to unregister ${accountId} which has a stale signature`

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1124,7 +1124,12 @@ export class NotifyEngine extends INotifyEngine {
 
     if(existingIdentity) {
       if(this.checkIfSignedStatementIsStale(accountId, NOTIFY_AUTHORIZATION_STATEMENT)) {
-        await this.client.identityKeys.unregisterIdentity({account: accountId})
+	try {
+          await this.client.identityKeys.unregisterIdentity({account: accountId})
+	}
+	catch {
+	  throw new Error(`Failed to unregister ${accountId} which has a stale signature`)
+	}
       }
     }
     

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1108,6 +1108,26 @@ export class NotifyEngine extends INotifyEngine {
     statement: string,
     domain: string
   ): Promise<string> => {
+
+    let existingIdentity = false;
+
+    try {
+      // TODO: Add "hasIdentity" method in identityKeys utils
+      // since `getIdentity` throws if no identity key is present
+      if(await this.client.identityKeys.getIdentity({account: accountId})) {
+	existingIdentity = true;
+      }
+    }
+    catch (e) {
+      existingIdentity = false;
+    }
+
+    if(existingIdentity) {
+      if(this.checkIfSignedStatementIsStale(accountId, NOTIFY_AUTHORIZATION_STATEMENT)) {
+        await this.client.identityKeys.unregisterIdentity({account: accountId})
+      }
+    }
+    
     return this.client.identityKeys.registerIdentity({
       accountId,
       onSign,

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1139,6 +1139,11 @@ export class NotifyEngine extends INotifyEngine {
       }
     }
 
+    this.client.signedStatements.set(accountId, {
+      account: accountId,
+      statement,
+    });
+
     return this.client.identityKeys.registerIdentity({
       accountId,
       onSign,

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1108,31 +1108,37 @@ export class NotifyEngine extends INotifyEngine {
     statement: string,
     domain: string
   ): Promise<string> => {
-
     let existingIdentity = false;
 
     try {
       // TODO: Add "hasIdentity" method in identityKeys utils
       // since `getIdentity` throws if no identity key is present
-      if(await this.client.identityKeys.getIdentity({account: accountId})) {
-	existingIdentity = true;
+      if (await this.client.identityKeys.getIdentity({ account: accountId })) {
+        existingIdentity = true;
       }
-    }
-    catch (e) {
+    } catch (e) {
       existingIdentity = false;
     }
 
-    if(existingIdentity) {
-      if(this.checkIfSignedStatementIsStale(accountId, NOTIFY_AUTHORIZATION_STATEMENT)) {
-	try {
-          await this.client.identityKeys.unregisterIdentity({account: accountId})
-	}
-	catch {
-	  throw new Error(`Failed to unregister ${accountId} which has a stale signature`)
-	}
+    if (existingIdentity) {
+      if (
+        this.checkIfSignedStatementIsStale(
+          accountId,
+          NOTIFY_AUTHORIZATION_STATEMENT
+        )
+      ) {
+        try {
+          await this.client.identityKeys.unregisterIdentity({
+            account: accountId,
+          });
+        } catch {
+          throw new Error(
+            `Failed to unregister ${accountId} which has a stale signature`
+          );
+        }
       }
     }
-    
+
     return this.client.identityKeys.registerIdentity({
       accountId,
       onSign,
@@ -1244,9 +1250,13 @@ export class NotifyEngine extends INotifyEngine {
   };
 
   // returns true if statement is stale, false otherwise.
-  private checkIfSignedStatementIsStale = (account: string, currentStatement: string) => {
-    const hasSignedStatement = this.client.signedStatements.keys.includes(account);
-    if(!hasSignedStatement) {
+  private checkIfSignedStatementIsStale = (
+    account: string,
+    currentStatement: string
+  ) => {
+    const hasSignedStatement =
+      this.client.signedStatements.keys.includes(account);
+    if (!hasSignedStatement) {
       // if there is no signed statement, then this account's statement was signed
       // previous to this function (and thus the latest statement) being introduced
       // therefore, it is stale.
@@ -1255,12 +1265,12 @@ export class NotifyEngine extends INotifyEngine {
 
     const signedStatement = this.client.signedStatements.get(account);
 
-    if(signedStatement.statement !== currentStatement) {
+    if (signedStatement.statement !== currentStatement) {
       return true;
     }
 
     return false;
-  }
+  };
 
   private watchLastWatchedAccountIfExists = async () => {
     // If an account was previously watched

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1108,19 +1108,8 @@ export class NotifyEngine extends INotifyEngine {
     statement: string,
     domain: string
   ): Promise<string> => {
-    let existingIdentity = false;
 
-    try {
-      // TODO: Add "hasIdentity" method in identityKeys utils
-      // since `getIdentity` throws if no identity key is present
-      if (await this.client.identityKeys.getIdentity({ account: accountId })) {
-        existingIdentity = true;
-      }
-    } catch (e) {
-      existingIdentity = false;
-    }
-
-    if (existingIdentity) {
+    if (await this.client.identityKeys.hasIdentity({account: accountId})) {
       if (
         this.checkIfSignedStatementIsStale(
           accountId,

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1139,17 +1139,19 @@ export class NotifyEngine extends INotifyEngine {
       }
     }
 
-    this.client.signedStatements.set(accountId, {
-      account: accountId,
-      statement,
-    });
-
-    return this.client.identityKeys.registerIdentity({
+    const registeredIdentity = await this.client.identityKeys.registerIdentity({
       accountId,
       onSign,
       statement,
       domain,
     });
+
+    this.client.signedStatements.set(accountId, {
+      account: accountId,
+      statement,
+    });
+
+    return registeredIdentity;
   };
 
   private resolveKeys = async (

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1108,8 +1108,7 @@ export class NotifyEngine extends INotifyEngine {
     statement: string,
     domain: string
   ): Promise<string> => {
-
-    if (await this.client.identityKeys.hasIdentity({account: accountId})) {
+    if (await this.client.identityKeys.hasIdentity({ account: accountId })) {
       if (
         this.checkIfSignedStatementIsStale(
           accountId,

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -242,7 +242,10 @@ export abstract class INotifyClient {
     }
   >;
 
-  public abstract signedStatements: IStore<string, { statement: string, account: string }>
+  public abstract signedStatements: IStore<
+    string,
+    { statement: string; account: string }
+  >;
 
   public abstract lastWatchedAccount: IStore<
     typeof LAST_WATCHED_KEY,

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -242,6 +242,8 @@ export abstract class INotifyClient {
     }
   >;
 
+  public abstract signedStatements: IStore<string, { statement: string, account: string }>
+
   public abstract lastWatchedAccount: IStore<
     typeof LAST_WATCHED_KEY,
     {

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -70,6 +70,36 @@ describe("Notify", () => {
       expect(wallet.core.pairing).toBeDefined();
     });
 
+    describe("register", () => {
+      it("can handle stale statements", async () => {
+	let onSignCalledTimes = 0;
+	const countedOnSign = async (message: string) => {
+	  console.log("Calling sign")
+	  onSignCalledTimes += 1;
+	  return onSign(message);
+	}
+	
+	console.log("registering 1")
+	const identityKey1 = await wallet.register({account, onSign: countedOnSign, domain: gmDappMetadata.appDomain})
+
+	await wallet.signedStatements.set(account, { statement: "false statement", account });
+
+	console.log("registering 2")
+	const identityKey2 = await wallet.register({account, onSign: countedOnSign, domain: gmDappMetadata.appDomain})
+	console.log("finished registering 2")
+
+	await waitForEvent(() => onSignCalledTimes === 2);
+
+	expect(identityKey1).not.to.equal(identityKey2);
+
+	const identityKey3 = await wallet.register({account, onSign: countedOnSign, domain: gmDappMetadata.appDomain})
+
+	expect(identityKey3).toEqual(identityKey2);
+
+	expect(onSignCalledTimes).toEqual(2);
+      })
+    })
+
     describe("subscribe", () => {
       it("can issue a `notify_subscription` request and handle the response", async () => {
         let gotNotifySubscriptionResponse = false;

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -74,19 +74,15 @@ describe("Notify", () => {
       it("can handle stale statements", async () => {
 	let onSignCalledTimes = 0;
 	const countedOnSign = async (message: string) => {
-	  console.log("Calling sign")
 	  onSignCalledTimes += 1;
 	  return onSign(message);
 	}
 	
-	console.log("registering 1")
 	const identityKey1 = await wallet.register({account, onSign: countedOnSign, domain: gmDappMetadata.appDomain})
 
 	await wallet.signedStatements.set(account, { statement: "false statement", account });
 
-	console.log("registering 2")
 	const identityKey2 = await wallet.register({account, onSign: countedOnSign, domain: gmDappMetadata.appDomain})
-	console.log("finished registering 2")
 
 	await waitForEvent(() => onSignCalledTimes === 2);
 

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -72,29 +72,44 @@ describe("Notify", () => {
 
     describe("register", () => {
       it("can handle stale statements", async () => {
-	let onSignCalledTimes = 0;
-	const countedOnSign = async (message: string) => {
-	  onSignCalledTimes += 1;
-	  return onSign(message);
-	}
-	
-	const identityKey1 = await wallet.register({account, onSign: countedOnSign, domain: gmDappMetadata.appDomain})
+        let onSignCalledTimes = 0;
+        const countedOnSign = async (message: string) => {
+          onSignCalledTimes += 1;
+          return onSign(message);
+        };
 
-	await wallet.signedStatements.set(account, { statement: "false statement", account });
+        const identityKey1 = await wallet.register({
+          account,
+          onSign: countedOnSign,
+          domain: gmDappMetadata.appDomain,
+        });
 
-	const identityKey2 = await wallet.register({account, onSign: countedOnSign, domain: gmDappMetadata.appDomain})
+        await wallet.signedStatements.set(account, {
+          statement: "false statement",
+          account,
+        });
 
-	await waitForEvent(() => onSignCalledTimes === 2);
+        const identityKey2 = await wallet.register({
+          account,
+          onSign: countedOnSign,
+          domain: gmDappMetadata.appDomain,
+        });
 
-	expect(identityKey1).not.to.equal(identityKey2);
+        await waitForEvent(() => onSignCalledTimes === 2);
 
-	const identityKey3 = await wallet.register({account, onSign: countedOnSign, domain: gmDappMetadata.appDomain})
+        expect(identityKey1).not.to.equal(identityKey2);
 
-	expect(identityKey3).toEqual(identityKey2);
+        const identityKey3 = await wallet.register({
+          account,
+          onSign: countedOnSign,
+          domain: gmDappMetadata.appDomain,
+        });
 
-	expect(onSignCalledTimes).toEqual(2);
-      })
-    })
+        expect(identityKey3).toEqual(identityKey2);
+
+        expect(onSignCalledTimes).toEqual(2);
+      });
+    });
 
     describe("subscribe", () => {
       it("can issue a `notify_subscription` request and handle the response", async () => {


### PR DESCRIPTION
# Changes
- add `signedStatements` store
- store signedStatements after successful register
- on `register`, if an account with existing signature is called, a check will be run if they have a stale statement. If they do, they will be prompted to register again
- Created this issue to match the TODO: https://github.com/WalletConnect/walletconnect-utils/issues/139