### PR TITLE
feat: use explorer api for config

### DIFF
--- a/packages/notify-client/src/constants/clients.ts
+++ b/packages/notify-client/src/constants/clients.ts
@@ -5,8 +5,9 @@ export const NOTIFY_WALLET_CLIENT_DEFAULT_NAME = "notifyClient";
 
 export const NOTIFY_CLIENT_STORAGE_PREFIX = `${NOTIFY_CLIENT_PROTOCOL}@${NOTIFY_CLIENT_VERSION}:${NOTIFY_CLIENT_CONTEXT}:`;
 
-export const DEFAULT_NOTIFY_SERVER_URL = "https://notify.walletconnect.com";
 export const DEFAULT_RELAY_SERVER_URL = "wss://relay.walletconnect.com";
+export const DEFAULT_NOTIFY_SERVER_URL = "https://notify.walletconnect.com";
+export const DEFAULT_EXPLORER_API_URL = "https://explorer-api.walletconnect.com/w3i/v1";
 export const DEFAULT_KEYSERVER_URL = "https://keys.walletconnect.com";
 
 export const LAST_WATCHED_KEY = "lastWatched";

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -211,14 +211,15 @@ export declare namespace NotifyClientTypes {
   }
 
   interface NotifyConfigDocument {
-    schemaVersion: number;
-    types: Array<{
+    id: string
+    name: Metadata["name"];
+    notificationTypes: Array<{
+      id: string
       name: string;
       description: string;
     }>;
-    name: Metadata["name"];
     description: Metadata["description"];
-    icons: Metadata["icons"];
+    image_url: Metadata["icons"];
   }
 }
 

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -197,6 +197,8 @@ describe("Notify", () => {
 
         const subscriptions = wallet.subscriptions.getAll();
 
+	console.log({vals: Object.values(subscriptions[0].scope)})
+
         // Ensure all scopes are enabled in the initial subscription.
         expect(
           Object.values(subscriptions[0].scope)


### PR DESCRIPTION
Resolves #61 

# Changes
- Use explorer api for fetching the notify config instead of getting the config from `dapp_url/.well-known/wc-notify-config.json`
- use `type.id` instead of `type.name` for operations on sub scopes
