### PR TITLE
use a new statement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6132,7 +6132,7 @@
     },
     "packages/notify-client": {
       "name": "@walletconnect/notify-client",
-      "version": "0.14.0",
+      "version": "0.14.1-b230b1",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^1.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6132,7 +6132,7 @@
     },
     "packages/notify-client": {
       "name": "@walletconnect/notify-client",
-      "version": "0.14.1-2065e7",
+      "version": "0.14.1-424117",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^1.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6132,7 +6132,7 @@
     },
     "packages/notify-client": {
       "name": "@walletconnect/notify-client",
-      "version": "0.14.1-bb22c8c",
+      "version": "0.14.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^1.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6132,7 +6132,7 @@
     },
     "packages/notify-client": {
       "name": "@walletconnect/notify-client",
-      "version": "0.14.1-424117",
+      "version": "0.14.1-bb22c8c",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^1.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6132,7 +6132,7 @@
     },
     "packages/notify-client": {
       "name": "@walletconnect/notify-client",
-      "version": "0.14.1-b230b1",
+      "version": "0.14.1-2065e7",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^1.7.3",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/notify-client",
   "description": "WalletConnect Notify Client",
-  "version": "0.14.1-2065e7",
+  "version": "0.14.1-424117",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/notify-client-js/",
   "license": "Apache-2.0",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/notify-client",
   "description": "WalletConnect Notify Client",
-  "version": "0.14.1-bb22c8c",
+  "version": "0.14.1",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/notify-client-js/",
   "license": "Apache-2.0",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/notify-client",
   "description": "WalletConnect Notify Client",
-  "version": "0.14.1-424117",
+  "version": "0.14.1-bb22c8c",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/notify-client-js/",
   "license": "Apache-2.0",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/notify-client",
   "description": "WalletConnect Notify Client",
-  "version": "0.14.0",
+  "version": "0.14.1-b230b1",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/notify-client-js/",
   "license": "Apache-2.0",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/notify-client",
   "description": "WalletConnect Notify Client",
-  "version": "0.14.1-b230b1",
+  "version": "0.14.1-2065e7",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/notify-client-js/",
   "license": "Apache-2.0",

--- a/packages/notify-client/src/constants/clients.ts
+++ b/packages/notify-client/src/constants/clients.ts
@@ -5,8 +5,10 @@ export const NOTIFY_WALLET_CLIENT_DEFAULT_NAME = "notifyClient";
 
 export const NOTIFY_CLIENT_STORAGE_PREFIX = `${NOTIFY_CLIENT_PROTOCOL}@${NOTIFY_CLIENT_VERSION}:${NOTIFY_CLIENT_CONTEXT}:`;
 
-export const DEFAULT_NOTIFY_SERVER_URL = "https://notify.walletconnect.com";
 export const DEFAULT_RELAY_SERVER_URL = "wss://relay.walletconnect.com";
+export const DEFAULT_NOTIFY_SERVER_URL = "https://notify.walletconnect.com";
+export const DEFAULT_EXPLORER_API_URL =
+  "https://explorer-api.walletconnect.com/w3i/v1";
 export const DEFAULT_KEYSERVER_URL = "https://keys.walletconnect.com";
 
 export const LAST_WATCHED_KEY = "lastWatched";

--- a/packages/notify-client/src/constants/engine.ts
+++ b/packages/notify-client/src/constants/engine.ts
@@ -4,8 +4,10 @@ import { JsonRpcTypes, RpcOpts } from "../types";
 // JWT-related constants
 export const JWT_SCP_SEPARATOR = " ";
 
-export const NOTIFY_AUTHORIZATION_STATEMENT =
-  "I further authorize this app to send and receive messages on my behalf using my WalletConnect identity. Read more at https://walletconnect.com/identity";
+export const NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS =
+  "I further authorize this app to send and receive messages on my behalf for ALL domains using my WalletConnect identity. Read more at https://walletconnect.com/identity";
+export const NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN =
+  "I further authorize this app to send and receive messages on my behalf for THIS domain using my WalletConnect identity. Read more at https://walletconnect.com/identity";
 
 export const DID_WEB_PREFIX = "did:web:";
 

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -29,7 +29,8 @@ import {
   ENGINE_RPC_OPTS,
   JWT_SCP_SEPARATOR,
   LAST_WATCHED_KEY,
-  NOTIFY_AUTHORIZATION_STATEMENT,
+  NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS,
+  NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN,
 } from "../constants";
 import { INotifyEngine, JsonRpcTypes, NotifyClientTypes } from "../types";
 import { getDappUrl } from "../utils/formats";
@@ -61,10 +62,13 @@ export class NotifyEngine extends INotifyEngine {
 
   public register: INotifyEngine["register"] = async ({
     account,
+    isLimited,
     onSign,
     domain,
   }) => {
-    const statement = NOTIFY_AUTHORIZATION_STATEMENT;
+    const statement = isLimited
+      ? NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN
+      : NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS;
 
     // Retrieve existing identity or register a new one for this account on this device.
     const identity = await this.registerIdentity(

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -66,7 +66,7 @@ export class NotifyEngine extends INotifyEngine {
     onSign,
     domain,
   }) => {
-    // explicity check if it was set to false because null/undefined should count as
+    // Explicitly check if it was set to false because null/undefined should count as
     // as "true" since by default it should be limited. The default of `isLimited` is
     // true.
     const statement =

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -763,7 +763,11 @@ export class NotifyEngine extends INotifyEngine {
     return hashKey(notifyId);
   }
 
-  private async watchSubscriptions(accountId: string, appDomain: string, isLimited: boolean) {
+  private async watchSubscriptions(
+    accountId: string,
+    appDomain: string,
+    isLimited: boolean
+  ) {
     const notifyKeys = await this.resolveKeys(this.client.notifyServerUrl);
 
     // Derive req topic from did.json
@@ -799,7 +803,7 @@ export class NotifyEngine extends INotifyEngine {
       aud: encodeEd25519Key(notifyKeys.dappIdentityKey),
       ksu: this.client.keyserverUrl,
       sub: composeDidPkh(accountId),
-      app: isLimited? `did:web:${appDomain}` : null,
+      app: isLimited ? `did:web:${appDomain}` : null,
     };
 
     const generatedAuth = await this.client.identityKeys.generateIdAuth(
@@ -829,7 +833,7 @@ export class NotifyEngine extends INotifyEngine {
     this.client.lastWatchedAccount.set(LAST_WATCHED_KEY, {
       [LAST_WATCHED_KEY]: accountId,
       appDomain,
-      isLimited
+      isLimited,
     });
 
     this.client.logger.info("watchSubscriptions >", "requestId >", id);
@@ -1271,8 +1275,11 @@ export class NotifyEngine extends INotifyEngine {
   private watchLastWatchedAccountIfExists = async () => {
     // If an account was previously watched
     if (this.client.lastWatchedAccount.keys.length === 1) {
-      const { lastWatched: account, appDomain, isLimited } =
-        this.client.lastWatchedAccount.get(LAST_WATCHED_KEY);
+      const {
+        lastWatched: account,
+        appDomain,
+        isLimited,
+      } = this.client.lastWatchedAccount.get(LAST_WATCHED_KEY);
 
       try {
         // Account for invalid state where the last watched account does not have an identity.

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -66,9 +66,12 @@ export class NotifyEngine extends INotifyEngine {
     onSign,
     domain,
   }) => {
-    const statement = isLimited
-      ? NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN
-      : NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS;
+    // explicity check if it was set to false because null/undefined should count as
+    // as "true" since by default it should be limited. The default of `isLimited` is
+    // true.
+    const statement = isLimited === false
+      ? NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS
+      : NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN;
 
     // Retrieve existing identity or register a new one for this account on this device.
     const identity = await this.registerIdentity(

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -25,6 +25,7 @@ import axios from "axios";
 import jwtDecode, { InvalidTokenError } from "jwt-decode";
 
 import {
+  DEFAULT_EXPLORER_API_URL,
   DID_WEB_PREFIX,
   ENGINE_RPC_OPTS,
   JWT_SCP_SEPARATOR,
@@ -101,7 +102,7 @@ export class NotifyEngine extends INotifyEngine {
 
     const dappUrl = getDappUrl(appDomain);
     const { dappPublicKey, dappIdentityKey } = await this.resolveKeys(dappUrl);
-    const notifyConfig = await this.resolveNotifyConfig(dappUrl);
+    const notifyConfig = await this.resolveNotifyConfig(appDomain);
 
     this.client.logger.info(
       `[Notify] subscribe > publicKey for ${dappUrl} is: ${dappPublicKey}`
@@ -125,8 +126,8 @@ export class NotifyEngine extends INotifyEngine {
     });
     const issuedAt = Math.round(Date.now() / 1000);
     const expiry = issuedAt + ENGINE_RPC_OPTS["wc_notifySubscribe"].req.ttl;
-    const scp = notifyConfig.types
-      .map((type) => type.name)
+    const scp = notifyConfig.notificationTypes
+      .map((type) => type.id)
       .join(JWT_SCP_SEPARATOR);
     const payload: NotifyClientTypes.SubscriptionJWTClaims = {
       iat: issuedAt,
@@ -876,9 +877,8 @@ export class NotifyEngine extends INotifyEngine {
     // Update all subscriptions to account for any changes in scope.
     const updateSubscriptionsPromises = claims.sbs.map(async (sub) => {
       const sbTopic = hashKey(sub.symKey);
-      const dappUrl = getDappUrl(sub.appDomain);
-      const dappConfig = await this.resolveNotifyConfig(dappUrl);
-      const scopeMap = this.generateScopeMap(dappConfig, sub);
+      const notifyConfig = await this.resolveNotifyConfig(sub.appDomain);
+      const scopeMap = this.generateScopeMap(notifyConfig, sub);
 
       await this.client.subscriptions.set(sbTopic, {
         account: sub.account,
@@ -887,9 +887,9 @@ export class NotifyEngine extends INotifyEngine {
         scope: scopeMap,
         symKey: sub.symKey,
         metadata: {
-          name: dappConfig.name,
-          description: dappConfig.description,
-          icons: dappConfig.icons,
+          name: notifyConfig.name,
+          description: notifyConfig.description,
+          icons: notifyConfig.image_url,
           appDomain: sub.appDomain,
         },
         relay: {
@@ -1214,14 +1214,13 @@ export class NotifyEngine extends INotifyEngine {
   };
 
   private resolveNotifyConfig = async (
-    dappUrl: string
+    dappDomain: string
   ): Promise<NotifyClientTypes.NotifyConfigDocument> => {
+    const dappConfigUrl = `${DEFAULT_EXPLORER_API_URL}/notify-config?projectId=${this.client.core.projectId}&appDomain=${dappDomain}`;
     try {
       // Fetch dapp's Notify config from its hosted wc-notify-config.
-      const notifyConfigResp = await axios.get(
-        `${dappUrl}/.well-known/wc-notify-config.json`
-      );
-      const notifyConfig = notifyConfigResp.data;
+      const notifyConfigResp = await axios.get(dappConfigUrl);
+      const notifyConfig = notifyConfigResp.data.data;
 
       this.client.logger.info(
         `[Notify] subscribe > got notify config: ${JSON.stringify(
@@ -1231,7 +1230,7 @@ export class NotifyEngine extends INotifyEngine {
       return notifyConfig;
     } catch (error: any) {
       throw new Error(
-        `Failed to fetch dapp's Notify config from ${dappUrl}/.well-known/wc-notify-config.json. Error: ${error.message}`
+        `Failed to fetch dapp's Notify config from ${dappConfigUrl}. Error: ${error.message}`
       );
     }
   };
@@ -1241,12 +1240,12 @@ export class NotifyEngine extends INotifyEngine {
     serverSub: NotifyClientTypes.NotifyServerSubscription
   ): NotifyClientTypes.ScopeMap => {
     return Object.fromEntries(
-      dappConfig.types.map((type) => {
+      dappConfig.notificationTypes.map((type) => {
         return [
-          type.name,
+          type.id,
           {
             ...type,
-            enabled: serverSub.scope.includes(type.name),
+            enabled: serverSub.scope.includes(type.id),
           },
         ];
       })

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -69,9 +69,10 @@ export class NotifyEngine extends INotifyEngine {
     // explicity check if it was set to false because null/undefined should count as
     // as "true" since by default it should be limited. The default of `isLimited` is
     // true.
-    const statement = isLimited === false
-      ? NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS
-      : NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN;
+    const statement =
+      isLimited === false
+        ? NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS
+        : NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN;
 
     // Retrieve existing identity or register a new one for this account on this device.
     const identity = await this.registerIdentity(

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -67,7 +67,8 @@ export declare namespace NotifyClientTypes {
     appDomain: string;
   }
 
-  type ScopeMap = Record<string, { description: string; enabled: boolean }>;
+  type ScopeMap = Record<string, { name: string, id: string, 
+    description: string; enabled: boolean }>;
 
   interface NotifySubscription {
     topic: string;

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -59,7 +59,11 @@ export declare namespace NotifyClientTypes {
   interface Metadata {
     name: string;
     description: string;
-    icons: string[];
+    icons: {
+      sm: string;
+      md: string;
+      lg: string;
+    };
     appDomain: string;
   }
 
@@ -211,14 +215,15 @@ export declare namespace NotifyClientTypes {
   }
 
   interface NotifyConfigDocument {
-    schemaVersion: number;
-    types: Array<{
+    id: string;
+    name: Metadata["name"];
+    notificationTypes: Array<{
+      id: string;
       name: string;
       description: string;
     }>;
-    name: Metadata["name"];
     description: Metadata["description"];
-    icons: Metadata["icons"];
+    image_url: Metadata["icons"];
   }
 }
 

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -250,6 +250,8 @@ export abstract class INotifyClient {
   public abstract lastWatchedAccount: IStore<
     typeof LAST_WATCHED_KEY,
     {
+      isLimited: boolean,
+      appDomain: string,
       [LAST_WATCHED_KEY]: string;
     }
   >;

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -250,8 +250,8 @@ export abstract class INotifyClient {
   public abstract lastWatchedAccount: IStore<
     typeof LAST_WATCHED_KEY,
     {
-      isLimited: boolean,
-      appDomain: string,
+      isLimited: boolean;
+      appDomain: string;
       [LAST_WATCHED_KEY]: string;
     }
   >;

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -67,8 +67,10 @@ export declare namespace NotifyClientTypes {
     appDomain: string;
   }
 
-  type ScopeMap = Record<string, { name: string, id: string, 
-    description: string; enabled: boolean }>;
+  type ScopeMap = Record<
+    string,
+    { name: string; id: string; description: string; enabled: boolean }
+  >;
 
   interface NotifySubscription {
     topic: string;

--- a/packages/notify-client/src/types/engine.ts
+++ b/packages/notify-client/src/types/engine.ts
@@ -32,6 +32,7 @@ export abstract class INotifyEngine {
   public abstract register(params: {
     account: string;
     onSign: (message: string) => Promise<string>;
+    isLimited?: boolean;
     domain: string;
   }): Promise<string>;
 

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -604,7 +604,7 @@ describe("Notify", () => {
       });
 
       it("correctly uses limit", async () => {
-        const storageLoc1 = generateClientDbName("notifyTest1");
+        const storageLoc1 = generateClientDbName("notifyTestLimit1");
         const wallet1 = await NotifyClient.init({
           name: "testNotifyClient1",
           logger: "error",
@@ -631,7 +631,7 @@ describe("Notify", () => {
 
         await waitForEvent(() => wallet1ReceivedChangedEvent);
 
-        const storageLoc2 = generateClientDbName("notifyTest2");
+        const storageLoc2 = generateClientDbName("notifyTestLimit2");
         const wallet2 = await NotifyClient.init({
           name: "testNotifyClient2",
           logger: "error",
@@ -664,7 +664,7 @@ describe("Notify", () => {
           Object.keys(wallet1.getActiveSubscriptions()).sort()
         );
 
-        const storageLoc3 = generateClientDbName("notifyTest3");
+        const storageLoc3 = generateClientDbName("notifyTestLimit3");
         const wallet3 = await NotifyClient.init({
           name: "testNotifyClient3",
           logger: "error",

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -501,7 +501,7 @@ describe("Notify", () => {
       });
 
       it("automatically fires watchSubscriptions on init", async () => {
-        const storageLoc = generateClientDbName("notifyTest");
+        const storageLoc = generateClientDbName("notifyTestAutomatic");
         const wallet1 = await NotifyClient.init({
           name: "testNotifyClient1",
           logger: "error",
@@ -528,7 +528,6 @@ describe("Notify", () => {
 
         await waitForEvent(() => wallet1ReceivedChangedEvent);
 
-        const storageLoc2 = generateClientDbName("notifyTest2");
         const wallet2 = await NotifyClient.init({
           name: "testNotifyClient2",
           logger: "error",
@@ -536,7 +535,7 @@ describe("Notify", () => {
           relayUrl: DEFAULT_RELAY_URL,
           core: new Core({
             projectId,
-            storageOptions: { database: storageLoc2 },
+            storageOptions: { database: storageLoc },
           }),
           projectId,
         });

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -603,7 +603,7 @@ describe("Notify", () => {
         );
       });
 
-      it("correctly uses limit", async () => {
+      it("correctly handles limited access via `isLimited`", async () => {
         const storageLoc1 = generateClientDbName("notifyTestLimit1");
         const wallet1 = await NotifyClient.init({
           name: "testNotifyClient1",

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -80,6 +80,7 @@ describe("Notify", () => {
 
         const identityKey1 = await wallet.register({
           account,
+          isLimited: false,
           onSign: countedOnSign,
           domain: gmDappMetadata.appDomain,
         });
@@ -91,6 +92,7 @@ describe("Notify", () => {
 
         const identityKey2 = await wallet.register({
           account,
+          isLimited: false,
           onSign: countedOnSign,
           domain: gmDappMetadata.appDomain,
         });
@@ -101,6 +103,7 @@ describe("Notify", () => {
 
         const identityKey3 = await wallet.register({
           account,
+          isLimited: false,
           onSign: countedOnSign,
           domain: gmDappMetadata.appDomain,
         });
@@ -129,6 +132,7 @@ describe("Notify", () => {
         });
 
         await wallet.register({
+          isLimited: false,
           account,
           onSign,
           domain: gmDappMetadata.appDomain,
@@ -516,6 +520,7 @@ describe("Notify", () => {
         });
 
         await wallet1.register({
+          isLimited: false,
           account,
           onSign,
           domain: "unrelated.domain.com",
@@ -523,6 +528,7 @@ describe("Notify", () => {
 
         await waitForEvent(() => wallet1ReceivedChangedEvent);
 
+        const storageLoc2 = generateClientDbName("notifyTest2");
         const wallet2 = await NotifyClient.init({
           name: "testNotifyClient2",
           logger: "error",
@@ -530,7 +536,7 @@ describe("Notify", () => {
           relayUrl: DEFAULT_RELAY_URL,
           core: new Core({
             projectId,
-            storageOptions: { database: storageLoc },
+            storageOptions: { database: storageLoc2 },
           }),
           projectId,
         });
@@ -583,6 +589,7 @@ describe("Notify", () => {
         });
 
         await wallet2.register({
+          isLimited: false,
           account,
           onSign,
           domain: "unrelated.domain.com",
@@ -595,6 +602,99 @@ describe("Notify", () => {
         expect(wallet1.subscriptions.getAll().length).toEqual(
           wallet2.subscriptions.getAll().length
         );
+      });
+
+      it("correctly uses limit", async () => {
+        const storageLoc1 = generateClientDbName("notifyTest1");
+        const wallet1 = await NotifyClient.init({
+          name: "testNotifyClient1",
+          logger: "error",
+          keyserverUrl: DEFAULT_KEYSERVER_URL,
+          relayUrl: DEFAULT_RELAY_URL,
+          core: new Core({
+            projectId,
+            storageOptions: { database: storageLoc1 },
+          }),
+          projectId,
+        });
+
+        let wallet1ReceivedChangedEvent = false;
+        wallet1.on("notify_subscriptions_changed", () => {
+          wallet1ReceivedChangedEvent = true;
+        });
+
+        await wallet1.register({
+          isLimited: true,
+          account,
+          onSign,
+          domain: gmDappMetadata.appDomain,
+        });
+
+        await waitForEvent(() => wallet1ReceivedChangedEvent);
+
+        const storageLoc2 = generateClientDbName("notifyTest2");
+        const wallet2 = await NotifyClient.init({
+          name: "testNotifyClient2",
+          logger: "error",
+          keyserverUrl: DEFAULT_KEYSERVER_URL,
+          relayUrl: DEFAULT_RELAY_URL,
+          core: new Core({
+            projectId,
+            storageOptions: { database: storageLoc2 },
+          }),
+          projectId,
+        });
+
+        let wallet2ReceivedChangedEvent = false;
+        wallet2.on("notify_subscriptions_changed", () => {
+          wallet2ReceivedChangedEvent = true;
+        });
+
+        await wallet2.register({
+          isLimited: true,
+          account,
+          onSign,
+          domain: gmDappMetadata.appDomain,
+        });
+
+        await waitForEvent(() => wallet2ReceivedChangedEvent);
+
+        expect(wallet2ReceivedChangedEvent).toEqual(true);
+
+        expect(Object.keys(wallet2.getActiveSubscriptions()).sort()).toEqual(
+          Object.keys(wallet1.getActiveSubscriptions()).sort()
+        );
+
+        const storageLoc3 = generateClientDbName("notifyTest3");
+        const wallet3 = await NotifyClient.init({
+          name: "testNotifyClient3",
+          logger: "error",
+          keyserverUrl: DEFAULT_KEYSERVER_URL,
+          relayUrl: DEFAULT_RELAY_URL,
+          core: new Core({
+            projectId,
+            storageOptions: { database: storageLoc3 },
+          }),
+          projectId,
+        });
+
+        let wallet3ReceivedChangedEvent = false;
+        wallet3.on("notify_subscriptions_changed", () => {
+          wallet3ReceivedChangedEvent = true;
+        });
+
+        await wallet3.register({
+          isLimited: true,
+          account,
+          onSign,
+          domain: "unrelated.domain",
+        });
+
+        await waitForEvent(() => wallet3ReceivedChangedEvent);
+
+        expect(wallet3ReceivedChangedEvent).toEqual(true);
+
+        expect(Object.keys(wallet3.getActiveSubscriptions()).length).toEqual(0);
       });
     });
   });

--- a/packages/notify-client/test/helpers/notify.ts
+++ b/packages/notify-client/test/helpers/notify.ts
@@ -40,6 +40,7 @@ export const createNotifySubscription = async (
   await wallet.register({
     domain,
     account,
+    isLimited: false,
     onSign,
   });
 

--- a/packages/notify-client/test/helpers/notify.ts
+++ b/packages/notify-client/test/helpers/notify.ts
@@ -77,7 +77,7 @@ export const sendNotifyMessage = async (
       title: "Test Message",
       icon: "",
       url: "https://test.coms",
-      // gm_hourly notifiation ID, comes from Cloud.
+      // gm_hourly notification ID, taken from `gm-dapp` project on Cloud.
       type: "cad9a52d-9b0f-4aed-9cca-3e9568a079f9",
     },
     accounts: [account],

--- a/packages/notify-client/test/helpers/notify.ts
+++ b/packages/notify-client/test/helpers/notify.ts
@@ -77,6 +77,7 @@ export const sendNotifyMessage = async (
       title: "Test Message",
       icon: "",
       url: "https://test.coms",
+      // gm_hourly notifiation ID, comes from Cloud.
       type: "cad9a52d-9b0f-4aed-9cca-3e9568a079f9",
     },
     accounts: [account],

--- a/packages/notify-client/test/helpers/notify.ts
+++ b/packages/notify-client/test/helpers/notify.ts
@@ -39,7 +39,6 @@ export const createNotifySubscription = async (
 
   await wallet.register({
     domain,
-    isLimited: false,
     account,
     onSign,
   });
@@ -77,7 +76,7 @@ export const sendNotifyMessage = async (
       title: "Test Message",
       icon: "",
       url: "https://test.coms",
-      type: "gm_hourly",
+      type: "cad9a52d-9b0f-4aed-9cca-3e9568a079f9",
     },
     accounts: [account],
   };


### PR DESCRIPTION
# Changes
- use new statements per the new spec: https://github.com/WalletConnect/walletconnect-specs/pull/162
- ^ change already deployed on notify server
- keep track of `isLimited` flag when watching subscriptions on client init
- update `lastWatchedAccount` to keep track of `isLimited` flag