### PR TITLE
hotfix: update icons to spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6132,7 +6132,7 @@
     },
     "packages/notify-client": {
       "name": "@walletconnect/notify-client",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^1.7.3",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/notify-client",
   "description": "WalletConnect Notify Client",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/notify-client-js/",
   "license": "Apache-2.0",

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -889,7 +889,7 @@ export class NotifyEngine extends INotifyEngine {
         metadata: {
           name: notifyConfig.name,
           description: notifyConfig.description,
-          icons: notifyConfig.image_url,
+          icons: Object.values(notifyConfig.image_url),
           appDomain: sub.appDomain,
         },
         relay: {

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -223,9 +223,9 @@ export declare namespace NotifyClientTypes {
     }>;
     description: Metadata["description"];
     image_url: {
-      sm: string
-      md: string
-      lg: string
+      sm: string;
+      md: string;
+      lg: string;
     };
   }
 }

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -59,11 +59,7 @@ export declare namespace NotifyClientTypes {
   interface Metadata {
     name: string;
     description: string;
-    icons: {
-      sm: string;
-      md: string;
-      lg: string;
-    };
+    icons: string[];
     appDomain: string;
   }
 
@@ -226,7 +222,11 @@ export declare namespace NotifyClientTypes {
       description: string;
     }>;
     description: Metadata["description"];
-    image_url: Metadata["icons"];
+    image_url: {
+      sm: string
+      md: string
+      lg: string
+    };
   }
 }
 


### PR DESCRIPTION
- revert change where icons where made to be a `Record<string, string>`
- map icons coming from explorer to icon string array

this was an oversight in the previous PR, as I assumed the specs were changing accordingly.