### PR TITLE
feat: default metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6132,7 +6132,7 @@
     },
     "packages/notify-client": {
       "name": "@walletconnect/notify-client",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^1.7.3",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/notify-client",
   "description": "WalletConnect Notify Client",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/notify-client-js/",
   "license": "Apache-2.0",

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -126,9 +126,10 @@ export class NotifyEngine extends INotifyEngine {
     });
     const issuedAt = Math.round(Date.now() / 1000);
     const expiry = issuedAt + ENGINE_RPC_OPTS["wc_notifySubscribe"].req.ttl;
-    const scp = notifyConfig?.notificationTypes
-      .map((type) => type.id)
-      .join(JWT_SCP_SEPARATOR) ?? '';
+    const scp =
+      notifyConfig?.notificationTypes
+        .map((type) => type.id)
+        .join(JWT_SCP_SEPARATOR) ?? "";
     const payload: NotifyClientTypes.SubscriptionJWTClaims = {
       iat: issuedAt,
       exp: expiry,
@@ -878,7 +879,9 @@ export class NotifyEngine extends INotifyEngine {
     const updateSubscriptionsPromises = claims.sbs.map(async (sub) => {
       const sbTopic = hashKey(sub.symKey);
       const notifyConfig = await this.resolveNotifyConfig(sub.appDomain);
-      const scopeMap = notifyConfig? this.generateScopeMap(notifyConfig, sub) : {};
+      const scopeMap = notifyConfig
+        ? this.generateScopeMap(notifyConfig, sub)
+        : {};
 
       await this.client.subscriptions.set(sbTopic, {
         account: sub.account,
@@ -889,7 +892,7 @@ export class NotifyEngine extends INotifyEngine {
         metadata: {
           name: notifyConfig?.name ?? sub.appDomain,
           description: notifyConfig?.description ?? sub.appDomain,
-          icons: notifyConfig? Object.values(notifyConfig.image_url) : [],
+          icons: notifyConfig ? Object.values(notifyConfig.image_url) : [],
           appDomain: sub.appDomain,
         },
         relay: {


### PR DESCRIPTION
Resolves #65 

Default `name` and `description` to `appDomain`, use empty array for `scp`