### PR TITLE
feat: unregister

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6132,7 +6132,7 @@
     },
     "packages/notify-client": {
       "name": "@walletconnect/notify-client",
-      "version": "0.14.3",
+      "version": "0.14.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^1.7.3",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/notify-client",
   "description": "WalletConnect Notify Client",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/notify-client-js/",
   "license": "Apache-2.0",

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -186,6 +186,15 @@ export class NotifyClient extends INotifyClient {
     }
   };
 
+  public unregister: INotifyClient["unregister"] = async (params) => {
+    try {
+      return await this.engine.unregister(params);
+    } catch (error: any) {
+      this.logger.error(error.message);
+      throw error;
+    }
+  };
+
   // ---------- Events ----------------------------------------------- //
 
   public emit: INotifyClient["emit"] = (name, listener) => {

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -33,7 +33,7 @@ export class NotifyClient extends INotifyClient {
   public engine: INotifyClient["engine"];
   public subscriptions: INotifyClient["subscriptions"];
   public messages: INotifyClient["messages"];
-  public lastWatchedAccount: INotifyClient["lastWatchedAccount"];
+  public watchedAccounts: INotifyClient["watchedAccounts"];
   public signedStatements: INotifyClient["signedStatements"];
   public identityKeys: INotifyClient["identityKeys"];
 
@@ -85,12 +85,12 @@ export class NotifyClient extends INotifyClient {
       NOTIFY_CLIENT_STORAGE_PREFIX
     );
 
-    this.lastWatchedAccount = new Store(
+    this.watchedAccounts = new Store(
       this.core,
       this.logger,
-      "lastWatchedAccount",
+      "watchedAccounts",
       NOTIFY_CLIENT_STORAGE_PREFIX,
-      () => "lastWatched"
+      ({ account }: { account: string }) => account
     );
 
     this.identityKeys =
@@ -227,7 +227,7 @@ export class NotifyClient extends INotifyClient {
       await this.messages.init();
       await this.signedStatements.init();
       await this.identityKeys.init();
-      await this.lastWatchedAccount.init();
+      await this.watchedAccounts.init();
       await this.engine.init();
 
       this.logger.info(`NotifyClient Initialization Success`);

--- a/packages/notify-client/src/constants/clients.ts
+++ b/packages/notify-client/src/constants/clients.ts
@@ -10,5 +10,3 @@ export const DEFAULT_NOTIFY_SERVER_URL = "https://notify.walletconnect.com";
 export const DEFAULT_EXPLORER_API_URL =
   "https://explorer-api.walletconnect.com/w3i/v1";
 export const DEFAULT_KEYSERVER_URL = "https://keys.walletconnect.com";
-
-export const LAST_WATCHED_KEY = "lastWatched";

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -29,7 +29,6 @@ import {
   DID_WEB_PREFIX,
   ENGINE_RPC_OPTS,
   JWT_SCP_SEPARATOR,
-  LAST_WATCHED_KEY,
   NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS,
   NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN,
 } from "../constants";
@@ -876,7 +875,7 @@ export class NotifyEngine extends INotifyEngine {
       .getAll()
       .filter((account) => account.lastWatched);
     for (const watchedAccount of currentlastWatchedAccounts) {
-      await this.client.watchedAccounts.update(accountId, {
+      await this.client.watchedAccounts.update(watchedAccount.account, {
         lastWatched: false,
       });
     }
@@ -1330,13 +1329,14 @@ export class NotifyEngine extends INotifyEngine {
   };
 
   private watchLastWatchedAccountIfExists = async () => {
+    const lastWatched = this.client.watchedAccounts.getAll().find(acc => acc.lastWatched);
     // If an account was previously watched
-    if (this.client.lastWatchedAccount.keys.length === 1) {
+    if (lastWatched) {
       const {
-        lastWatched: account,
+        account,
         appDomain,
         isLimited,
-      } = this.client.lastWatchedAccount.get(LAST_WATCHED_KEY);
+      } = lastWatched;
 
       try {
         // Account for invalid state where the last watched account does not have an identity.

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -43,7 +43,10 @@ export class NotifyEngine extends INotifyEngine {
   private didDocMap = new Map<string, NotifyClientTypes.NotifyDidDocument>();
 
   // this should NOT be presisted in a store. Watched Keys are transient and generated every session.
-  private watchedAccountTopics = new Map<string, { reqTopic: string, resTopic: string }>
+  private watchedAccountTopics = new Map<
+    string,
+    { reqTopic: string; resTopic: string }
+  >();
 
   constructor(client: INotifyEngine["client"]) {
     super(client);
@@ -102,14 +105,16 @@ export class NotifyEngine extends INotifyEngine {
       // Unsubscribe from topics related to watching subscriptions
       const topics = this.watchedAccountTopics.get(account);
 
-      if(topics) {
-	await this.client.core.relayer.unsubscribe(topics.reqTopic);
-	await this.client.core.relayer.unsubscribe(topics.resTopic);
+      if (topics) {
+        await this.client.core.relayer.unsubscribe(topics.reqTopic);
+        await this.client.core.relayer.unsubscribe(topics.resTopic);
       }
 
       // Unsubscribe from subscription topics
-      for(const sub of Object.values(this.getActiveSubscriptions({account}))) {
-	await this.client.core.relayer.unsubscribe(sub.topic);
+      for (const sub of Object.values(
+        this.getActiveSubscriptions({ account })
+      )) {
+        await this.client.core.relayer.unsubscribe(sub.topic);
       }
 
       // unregister from identity server
@@ -865,7 +870,10 @@ export class NotifyEngine extends INotifyEngine {
       isLimited,
     });
 
-    this.watchedAccountTopics.set(accountId, { reqTopic: notifyServerWatchTopic, resTopic});
+    this.watchedAccountTopics.set(accountId, {
+      reqTopic: notifyServerWatchTopic,
+      resTopic,
+    });
 
     this.client.logger.info("watchSubscriptions >", "requestId >", id);
   }
@@ -1157,7 +1165,6 @@ export class NotifyEngine extends INotifyEngine {
     if (await this.client.identityKeys.hasIdentity({ account: accountId })) {
       if (this.checkIfSignedStatementIsStale(accountId, statement)) {
         try {
-
           await this.client.identityKeys.unregisterIdentity({
             account: accountId,
           });

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -95,19 +95,25 @@ export class NotifyEngine extends INotifyEngine {
 
   public unregister: INotifyEngine["unregister"] = async ({ account }) => {
     try {
-      // Unsubscribe from topics related to watching subscriptions
+      // Get information about watching subscriptions of account
       const watchedAccount = this.client.watchedAccounts.get(account);
 
+      // If account was watched
       if (watchedAccount) {
+	// and subscribed to a notify server watch topic
         if (
           this.client.core.relayer.subscriber.topicMap.topics.includes(
             watchedAccount.resTopic
           )
         ) {
+	  // unsubscribe from watch topic
           await this.client.core.relayer.unsubscribe(watchedAccount.resTopic);
         }
 
+
+	// If account was the last to be watched
 	if(watchedAccount.lastWatched) {
+	  // Remove last watched flag, to prevent watching on next init.
 	  await this.client.watchedAccounts.update(watchedAccount.account, { lastWatched: false })
 	}
       }
@@ -895,6 +901,7 @@ export class NotifyEngine extends INotifyEngine {
       });
     }
 
+    // Set new or overwrite existing account watch data.
     await this.client.watchedAccounts.set(accountId, {
       appDomain,
       account: accountId,
@@ -1343,6 +1350,7 @@ export class NotifyEngine extends INotifyEngine {
   };
 
   private watchLastWatchedAccountIfExists = async () => {
+    // Get account that was watched
     const lastWatched = this.client.watchedAccounts
       .getAll()
       .find((acc) => acc.lastWatched);

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -96,16 +96,20 @@ export class NotifyEngine extends INotifyEngine {
   public unregister: INotifyEngine["unregister"] = async ({ account }) => {
     try {
       // Unsubscribe from topics related to watching subscriptions
-      const topics = this.client.watchedAccounts.get(account);
+      const watchedAccount = this.client.watchedAccounts.get(account);
 
-      if (topics) {
+      if (watchedAccount) {
         if (
           this.client.core.relayer.subscriber.topicMap.topics.includes(
-            topics.resTopic
+            watchedAccount.resTopic
           )
         ) {
-          await this.client.core.relayer.unsubscribe(topics.resTopic);
+          await this.client.core.relayer.unsubscribe(watchedAccount.resTopic);
         }
+
+	if(watchedAccount.lastWatched) {
+	  await this.client.watchedAccounts.update(watchedAccount.account, { lastWatched: false })
+	}
       }
 
       // Unsubscribe from subscription topics

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -817,9 +817,8 @@ export class NotifyEngine extends INotifyEngine {
 
     try {
       const existingWatchEntry = this.client.watchedAccounts.get(accountId);
-	pubKeyY = existingWatchEntry.publicKeyY
-	privKeyY = existingWatchEntry.privateKeyY
-
+      pubKeyY = existingWatchEntry.publicKeyY;
+      privKeyY = existingWatchEntry.privateKeyY;
     } catch {
       pubKeyY = await this.client.core.crypto.generateKeyPair();
       privKeyY = this.client.core.crypto.keychain.get(pubKeyY);
@@ -1329,14 +1328,12 @@ export class NotifyEngine extends INotifyEngine {
   };
 
   private watchLastWatchedAccountIfExists = async () => {
-    const lastWatched = this.client.watchedAccounts.getAll().find(acc => acc.lastWatched);
+    const lastWatched = this.client.watchedAccounts
+      .getAll()
+      .find((acc) => acc.lastWatched);
     // If an account was previously watched
     if (lastWatched) {
-      const {
-        account,
-        appDomain,
-        isLimited,
-      } = lastWatched;
+      const { account, appDomain, isLimited } = lastWatched;
 
       try {
         // Account for invalid state where the last watched account does not have an identity.

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -100,22 +100,23 @@ export class NotifyEngine extends INotifyEngine {
 
       // If account was watched
       if (watchedAccount) {
-	// and subscribed to a notify server watch topic
+        // and subscribed to a notify server watch topic
         if (
           this.client.core.relayer.subscriber.topicMap.topics.includes(
             watchedAccount.resTopic
           )
         ) {
-	  // unsubscribe from watch topic
+          // unsubscribe from watch topic
           await this.client.core.relayer.unsubscribe(watchedAccount.resTopic);
         }
 
-
-	// If account was the last to be watched
-	if(watchedAccount.lastWatched) {
-	  // Remove last watched flag, to prevent watching on next init.
-	  await this.client.watchedAccounts.update(watchedAccount.account, { lastWatched: false })
-	}
+        // If account was the last to be watched
+        if (watchedAccount.lastWatched) {
+          // Remove last watched flag, to prevent watching on next init.
+          await this.client.watchedAccounts.update(watchedAccount.account, {
+            lastWatched: false,
+          });
+        }
       }
 
       // Unsubscribe from subscription topics

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -94,6 +94,16 @@ export class NotifyEngine extends INotifyEngine {
     return identity;
   };
 
+  public unregister: INotifyEngine["unregister"] = async ({ account }) => {
+    try {
+      await this.client.identityKeys.unregisterIdentity({ account });
+    } catch (error: any) {
+      this.client.logger.error(
+        `[Notify] Engine.unregister > failed to unregister > ${error.message}`
+      );
+    }
+  };
+
   public subscribe: INotifyEngine["subscribe"] = async ({
     appDomain,
     account,

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -259,7 +259,6 @@ export abstract class INotifyClient {
     {
       isLimited: boolean;
       appDomain: string;
-      reqTopic: string;
       resTopic: string;
       account: string;
       privateKeyY: string;

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -3,7 +3,6 @@ import { ErrorResponse } from "@walletconnect/jsonrpc-utils";
 import { CoreTypes, ICore, IStore, RelayerTypes } from "@walletconnect/types";
 import EventEmitter from "events";
 import { Logger } from "pino";
-import { LAST_WATCHED_KEY } from "../constants";
 
 import { INotifyEngine } from "./engine";
 
@@ -255,14 +254,20 @@ export abstract class INotifyClient {
     { statement: string; account: string }
   >;
 
-  public abstract lastWatchedAccount: IStore<
-    typeof LAST_WATCHED_KEY,
+  public abstract watchedAccounts: IStore<
+    string,
     {
       isLimited: boolean;
       appDomain: string;
-      [LAST_WATCHED_KEY]: string;
+      reqTopic: string;
+      resTopic: string;
+      account: string;
+      privateKeyY: string;
+      publicKeyY: string;
+      lastWatched: boolean;
     }
   >;
+
   public abstract identityKeys: IdentityKeys;
 
   public abstract subscriptions: IStore<

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -275,6 +275,7 @@ export abstract class INotifyClient {
   // ---------- Public Methods ------------------------------------------------------- //
 
   public abstract register: INotifyEngine["register"];
+  public abstract unregister: INotifyEngine["unregister"];
   public abstract subscribe: INotifyEngine["subscribe"];
   public abstract update: INotifyEngine["update"];
   public abstract decryptMessage: INotifyEngine["decryptMessage"];

--- a/packages/notify-client/src/types/engine.ts
+++ b/packages/notify-client/src/types/engine.ts
@@ -36,6 +36,8 @@ export abstract class INotifyEngine {
     domain: string;
   }): Promise<string>;
 
+  public abstract unregister(params: { account: string }): Promise<void>;
+
   public abstract subscribe(params: {
     appDomain: string;
     account: string;

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -131,13 +131,15 @@ describe("Notify", () => {
 
         const fetchUrl = `${DEFAULT_KEYSERVER_URL}/identity?publicKey=${identityKeyFetchFormat}`;
 
-        const responsePreUnregister = await fetch(fetchUrl);
+        const responsePreUnregister = await axios(fetchUrl);
 
         expect(responsePreUnregister.status).toEqual(200);
 
         await wallet.unregister({ account });
 
-        const responsePostUnregister = await fetch(fetchUrl);
+        const responsePostUnregister = await axios(fetchUrl, {
+	  validateStatus: () => true
+	});
 
         expect(responsePostUnregister.status).toEqual(404);
       });

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -154,11 +154,17 @@ describe("Notify", () => {
 
         expect(responsePreUnregister.status).toEqual(200);
 
+	let gotSub = false;
+	newClient.on('notify_subscriptions_changed', () => {
+	  gotSub = true;
+	})
+
         await newClient.subscribe({
           account: newAccount,
           appDomain: gmDappMetadata.appDomain,
         });
-
+	
+	await waitForEvent(() => gotSub);
         expect(newClient.subscriptions.getAll().length).toEqual(1);
 
         const subTopic = newClient.subscriptions.getAll()[0].topic;

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -119,7 +119,7 @@ describe("Notify", () => {
     describe("unregister", () => {
       it("can unregister", async () => {
         // using newly generated account to ensure clean slate for tests
-        // as this tests interacts with keys server
+        // as this test interacts with keys server
         const newWallet = EthersWallet.createRandom();
         const newAccount = `eip155:1:${newWallet.address}`;
 
@@ -170,9 +170,7 @@ describe("Notify", () => {
         const subTopic = newClient.subscriptions.getAll()[0].topic;
 
         expect(
-          Array.from(
-            newClient.core.relayer.subscriber.subscriptions.values()
-          ).some((sub) => sub.topic === subTopic)
+          newClient.core.relayer.subscriber.isSubscribed(subTopic)
         ).toEqual(true);
 
         await newClient.unregister({ account: newAccount });
@@ -181,9 +179,7 @@ describe("Notify", () => {
         expect(newClient.subscriptions.getAll().length).toEqual(1);
 
         expect(
-          Array.from(
-            newClient.core.relayer.subscriber.subscriptions.values()
-          ).some((sub) => sub.topic === subTopic)
+          newClient.core.relayer.subscriber.isSubscribed(subTopic)
         ).toEqual(false);
 
         const responsePostUnregister = await axios(fetchUrl, {

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -170,7 +170,7 @@ describe("Notify", () => {
         const subTopic = newClient.subscriptions.getAll()[0].topic;
 
         expect(
-          newClient.core.relayer.subscriber.isSubscribed(subTopic)
+          await newClient.core.relayer.subscriber.isSubscribed(subTopic)
         ).toEqual(true);
 
         await newClient.unregister({ account: newAccount });
@@ -179,7 +179,7 @@ describe("Notify", () => {
         expect(newClient.subscriptions.getAll().length).toEqual(1);
 
         expect(
-          newClient.core.relayer.subscriber.isSubscribed(subTopic)
+          await newClient.core.relayer.subscriber.isSubscribed(subTopic)
         ).toEqual(false);
 
         const responsePostUnregister = await axios(fetchUrl, {

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -154,17 +154,17 @@ describe("Notify", () => {
 
         expect(responsePreUnregister.status).toEqual(200);
 
-	let gotSub = false;
-	newClient.on('notify_subscriptions_changed', () => {
-	  gotSub = true;
-	})
+        let gotSub = false;
+        newClient.on("notify_subscriptions_changed", () => {
+          gotSub = true;
+        });
 
         await newClient.subscribe({
           account: newAccount,
           appDomain: gmDappMetadata.appDomain,
         });
-	
-	await waitForEvent(() => gotSub);
+
+        await waitForEvent(() => gotSub);
         expect(newClient.subscriptions.getAll().length).toEqual(1);
 
         const subTopic = newClient.subscriptions.getAll()[0].topic;

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -138,8 +138,8 @@ describe("Notify", () => {
         await wallet.unregister({ account });
 
         const responsePostUnregister = await axios(fetchUrl, {
-	  validateStatus: () => true
-	});
+          validateStatus: () => true,
+        });
 
         expect(responsePostUnregister.status).toEqual(404);
       });


### PR DESCRIPTION
# Changes
- Add unregister method per [spec](https://specs.walletconnect.com/2.0/specs/clients/notify/client-sdk-api)
- Persist keyY per account per device like iOS and Android do
- Remove `lastWatched` account store and replaced with generic `watchAccounts` store
- Refactor lastWatched logic to use new store
- Make `watchSubscriptions` mark new store with flag for last watched account and revert flag for other accounts
- Add test for unregister method
- prep for new non breaking release