### PR TITLE
Fix/handling of incomplete image config

### DIFF
--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -982,7 +982,7 @@ export class NotifyEngine extends INotifyEngine {
         metadata: {
           name: notifyConfig?.name ?? sub.appDomain,
           description: notifyConfig?.description ?? sub.appDomain,
-          icons: notifyConfig ? Object.values(notifyConfig.image_url) : [],
+          icons: notifyConfig?.image_url ? Object.values(notifyConfig.image_url) : [],
           appDomain: sub.appDomain,
         },
         relay: {

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -982,7 +982,9 @@ export class NotifyEngine extends INotifyEngine {
         metadata: {
           name: notifyConfig?.name ?? sub.appDomain,
           description: notifyConfig?.description ?? sub.appDomain,
-          icons: notifyConfig?.image_url ? Object.values(notifyConfig.image_url) : [],
+          icons: notifyConfig?.image_url
+            ? Object.values(notifyConfig.image_url)
+            : [],
           appDomain: sub.appDomain,
         },
         relay: {

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -221,7 +221,7 @@ export declare namespace NotifyClientTypes {
       description: string;
     }>;
     description: Metadata["description"];
-    image_url: {
+    image_url?: {
       sm: string;
       md: string;
       lg: string;


### PR DESCRIPTION
- Based on errors coming from this [sentry error](https://walletconnect.sentry.io/issues/?project=4505754150043648&query=is%3Aunresolved+Cannot+convert+undefined&referrer=issue-list&statsPeriod=14d), it seems like `image_url` can be `undefined` or `null`, not `{}` as previously assumed. 
- Implementation from explorer for reference: https://github.com/WalletConnect/explorer-api/blob/master/src/controllers/web3inbox/getNotifyConfig.ts#L77C1-L77C1
- This checks for correctness of `image_url`  instead of `notifyConfig` as a whole
