### PR TITLE
chore: bump identity keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1980,9 +1980,9 @@
       }
     },
     "node_modules/@walletconnect/identity-keys": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/identity-keys/-/identity-keys-0.2.2.tgz",
-      "integrity": "sha512-Od34t90Z+fFV3akTapgUbn+NlsgJEBRQ0dIckgT3VMWtQZ0kj3PXYIJL1YOmfpBMiU1n5VVGTkqgIRxMxWiWdg==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@walletconnect/identity-keys/-/identity-keys-0.2.3.tgz",
+      "integrity": "sha512-mu80J+FEiL24TEVuEO6vw1Tjs1sEMyHhui53W2VPaJMmlSa6wUSVLXTsONYZnW70uwlUo9D4R8VureWsZ6sBcg==",
       "dependencies": {
         "@noble/ed25519": "^1.7.1",
         "@walletconnect/cacao": "1.0.2",
@@ -7046,7 +7046,7 @@
         "@walletconnect/cacao": "1.0.2",
         "@walletconnect/core": "^2.10.5",
         "@walletconnect/did-jwt": "2.0.1",
-        "@walletconnect/identity-keys": "^0.2.2",
+        "@walletconnect/identity-keys": "^0.2.3",
         "@walletconnect/jsonrpc-utils": "1.0.7",
         "@walletconnect/time": "1.0.2",
         "@walletconnect/utils": "^2.10.5",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -34,7 +34,7 @@
     "@walletconnect/cacao": "1.0.2",
     "@walletconnect/core": "^2.10.5",
     "@walletconnect/did-jwt": "2.0.1",
-    "@walletconnect/identity-keys": "^0.2.2",
+    "@walletconnect/identity-keys": "^0.2.3",
     "@walletconnect/jsonrpc-utils": "1.0.7",
     "@walletconnect/time": "1.0.2",
     "@walletconnect/utils": "^2.10.5",


### PR DESCRIPTION
Bump identity to `0.2.3` to fix issue with optimistic persistence of keys