### PR TITLE
Refactor/use new register method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
+      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q=="
+    },
     "node_modules/@esbuild/android-arm": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.2.tgz",
@@ -1015,6 +1020,17 @@
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
       "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
     },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/ed25519": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
@@ -1025,6 +1041,17 @@
           "url": "https://paulmillr.com/funding/"
         }
       ]
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1424,6 +1451,39 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
+      "integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
+      "integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
+      "dependencies": {
+        "@noble/curves": "~1.2.0",
+        "@noble/hashes": "~1.3.2",
+        "@scure/base": "~1.1.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
+      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+      "dependencies": {
+        "@noble/hashes": "~1.3.0",
+        "@scure/base": "~1.1.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.6",
@@ -1980,9 +2040,9 @@
       }
     },
     "node_modules/@walletconnect/identity-keys": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@walletconnect/identity-keys/-/identity-keys-0.2.3.tgz",
-      "integrity": "sha512-mu80J+FEiL24TEVuEO6vw1Tjs1sEMyHhui53W2VPaJMmlSa6wUSVLXTsONYZnW70uwlUo9D4R8VureWsZ6sBcg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@walletconnect/identity-keys/-/identity-keys-1.0.0.tgz",
+      "integrity": "sha512-Ea3fG0cNfHCNKApb0/WH6VbCkL9WMOjiknw2VdQXEHrsepg9IyGA/Cq9whdL6S4JcKZNGkmUWepBjo0ls2BkIg==",
       "dependencies": {
         "@noble/ed25519": "^1.7.1",
         "@walletconnect/cacao": "1.0.2",
@@ -1990,7 +2050,8 @@
         "@walletconnect/did-jwt": "2.0.3",
         "@walletconnect/types": "^2.10.1",
         "@walletconnect/utils": "^2.10.1",
-        "axios": "^1.3.5"
+        "axios": "^1.3.5",
+        "viem": "^1.19.11"
       }
     },
     "node_modules/@walletconnect/identity-keys/node_modules/@walletconnect/did-jwt": {
@@ -2001,6 +2062,92 @@
         "@noble/ed25519": "1.7.3",
         "bs58": "5.0.0",
         "multiformats": "^9.9.0"
+      }
+    },
+    "node_modules/@walletconnect/identity-keys/node_modules/abitype": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.9.8.tgz",
+      "integrity": "sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wagmi-dev"
+        }
+      ],
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.19.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/identity-keys/node_modules/typescript": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/@walletconnect/identity-keys/node_modules/viem": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-1.19.11.tgz",
+      "integrity": "sha512-dbsXEWDBZkByuzJXAs/e01j7dpUJ5ICF5WcyntFwf8Y97n5vnC/91lAleSa6DA5V4WJvYZbhDpYeTctsMAQnhA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.0",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@scure/bip32": "1.3.2",
+        "@scure/bip39": "1.2.1",
+        "abitype": "0.9.8",
+        "isows": "1.0.3",
+        "ws": "8.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@walletconnect/identity-keys/node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@walletconnect/jsonrpc-provider": {
@@ -4896,6 +5043,20 @@
         "unfetch": "^4.2.0"
       }
     },
+    "node_modules/isows": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.3.tgz",
+      "integrity": "sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wagmi-dev"
+        }
+      ],
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
@@ -7046,7 +7207,7 @@
         "@walletconnect/cacao": "1.0.2",
         "@walletconnect/core": "^2.10.5",
         "@walletconnect/did-jwt": "2.0.1",
-        "@walletconnect/identity-keys": "^0.2.3",
+        "@walletconnect/identity-keys": "^1.0.0",
         "@walletconnect/jsonrpc-utils": "1.0.7",
         "@walletconnect/time": "1.0.2",
         "@walletconnect/utils": "^2.10.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,11 +47,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/@adraffy/ens-normalize": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz",
-      "integrity": "sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q=="
-    },
     "node_modules/@esbuild/android-arm": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.2.tgz",
@@ -1020,17 +1015,6 @@
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz",
       "integrity": "sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg=="
     },
-    "node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "dependencies": {
-        "@noble/hashes": "1.3.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@noble/ed25519": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
@@ -1041,17 +1025,6 @@
           "url": "https://paulmillr.com/funding/"
         }
       ]
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1451,39 +1424,6 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
       "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
       "dev": true
-    },
-    "node_modules/@scure/base": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
-      "integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==",
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip32": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.2.tgz",
-      "integrity": "sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==",
-      "dependencies": {
-        "@noble/curves": "~1.2.0",
-        "@noble/hashes": "~1.3.2",
-        "@scure/base": "~1.1.2"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip39": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
-      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
-      "dependencies": {
-        "@noble/hashes": "~1.3.0",
-        "@scure/base": "~1.1.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.6",
@@ -2040,18 +1980,19 @@
       }
     },
     "node_modules/@walletconnect/identity-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/identity-keys/-/identity-keys-1.0.0.tgz",
-      "integrity": "sha512-Ea3fG0cNfHCNKApb0/WH6VbCkL9WMOjiknw2VdQXEHrsepg9IyGA/Cq9whdL6S4JcKZNGkmUWepBjo0ls2BkIg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@walletconnect/identity-keys/-/identity-keys-1.0.1.tgz",
+      "integrity": "sha512-xcq5xmK0vTbJdw95UT4cNFrEMg6gr/hG+IIVj3q20drg+nmM5CnzV26uPTvnyo3gig3NVWkmjRJ054sdQmy4Zw==",
       "dependencies": {
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
         "@noble/ed25519": "^1.7.1",
         "@walletconnect/cacao": "1.0.2",
         "@walletconnect/core": "^2.10.1",
         "@walletconnect/did-jwt": "2.0.3",
         "@walletconnect/types": "^2.10.1",
         "@walletconnect/utils": "^2.10.1",
-        "axios": "^1.3.5",
-        "viem": "^1.19.11"
+        "axios": "^1.3.5"
       }
     },
     "node_modules/@walletconnect/identity-keys/node_modules/@walletconnect/did-jwt": {
@@ -2062,92 +2003,6 @@
         "@noble/ed25519": "1.7.3",
         "bs58": "5.0.0",
         "multiformats": "^9.9.0"
-      }
-    },
-    "node_modules/@walletconnect/identity-keys/node_modules/abitype": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-0.9.8.tgz",
-      "integrity": "sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wagmi-dev"
-        }
-      ],
-      "peerDependencies": {
-        "typescript": ">=5.0.4",
-        "zod": "^3 >=3.19.1"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@walletconnect/identity-keys/node_modules/typescript": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/@walletconnect/identity-keys/node_modules/viem": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-1.19.11.tgz",
-      "integrity": "sha512-dbsXEWDBZkByuzJXAs/e01j7dpUJ5ICF5WcyntFwf8Y97n5vnC/91lAleSa6DA5V4WJvYZbhDpYeTctsMAQnhA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "dependencies": {
-        "@adraffy/ens-normalize": "1.10.0",
-        "@noble/curves": "1.2.0",
-        "@noble/hashes": "1.3.2",
-        "@scure/bip32": "1.3.2",
-        "@scure/bip39": "1.2.1",
-        "abitype": "0.9.8",
-        "isows": "1.0.3",
-        "ws": "8.13.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.0.4"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@walletconnect/identity-keys/node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/@walletconnect/jsonrpc-provider": {
@@ -5043,20 +4898,6 @@
         "unfetch": "^4.2.0"
       }
     },
-    "node_modules/isows": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.3.tgz",
-      "integrity": "sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wagmi-dev"
-        }
-      ],
-      "peerDependencies": {
-        "ws": "*"
-      }
-    },
     "node_modules/jiti": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
@@ -7207,7 +7048,7 @@
         "@walletconnect/cacao": "1.0.2",
         "@walletconnect/core": "^2.10.5",
         "@walletconnect/did-jwt": "2.0.1",
-        "@walletconnect/identity-keys": "^1.0.0",
+        "@walletconnect/identity-keys": "^1.0.1",
         "@walletconnect/jsonrpc-utils": "1.0.7",
         "@walletconnect/time": "1.0.2",
         "@walletconnect/utils": "^2.10.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1910,9 +1910,9 @@
       }
     },
     "node_modules/@walletconnect/core": {
-      "version": "2.10.5",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.10.5.tgz",
-      "integrity": "sha512-QnGHkA05KzJrtqExPqXm/TsstM1uTDI8tQT0x86/DuR6LdiYEntzSpVjnv7kKK6Mo9UxlXfud431dNRfOW5uJg==",
+      "version": "2.10.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.10.6.tgz",
+      "integrity": "sha512-Z4vh4ZdfcoQjgPEOxeuF9HUZCVLtV3MgRbS/awLIj/omDrFnOwlBhxi5Syr4Y8muVGC0ocRetQYHae0/gX5crQ==",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.1",
         "@walletconnect/jsonrpc-provider": "1.0.13",
@@ -1925,8 +1925,8 @@
         "@walletconnect/relay-auth": "^1.0.4",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.5",
-        "@walletconnect/utils": "2.10.5",
+        "@walletconnect/types": "2.10.6",
+        "@walletconnect/utils": "2.10.6",
         "events": "^3.3.0",
         "lodash.isequal": "4.5.0",
         "uint8arrays": "^3.1.0"
@@ -2129,9 +2129,9 @@
       }
     },
     "node_modules/@walletconnect/types": {
-      "version": "2.10.5",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.10.5.tgz",
-      "integrity": "sha512-N8xaN7/Kob93rKxKDaT6oy6symgIkAwyLqq0/dLJEhXfv7S/gyNvDka4SosjVVTc4oTvE1+OmxNIR8pB1DuwJw==",
+      "version": "2.10.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.10.6.tgz",
+      "integrity": "sha512-WgHfiTG1yakmxheaBRiXhUdEmgxwrvsAdOIWaMf/spvrzVKYh6sHI3oyEEky5qj5jjiMiyQBeB57QamzCotbcQ==",
       "dependencies": {
         "@walletconnect/events": "^1.0.1",
         "@walletconnect/heartbeat": "1.2.1",
@@ -2142,9 +2142,9 @@
       }
     },
     "node_modules/@walletconnect/utils": {
-      "version": "2.10.5",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.10.5.tgz",
-      "integrity": "sha512-3yeclD9/AlPEIHBqBVzrHUO/KRAEIXVK0ViIQ5oUH+zT3TpdsDGDiW1Z0TsAQ1EiYoiiz8dOQzd80a3eZVwnrg==",
+      "version": "2.10.6",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.10.6.tgz",
+      "integrity": "sha512-oRsWWhN2+hi3aiDXrQEOfysz6FHQJGXLsNQPVt+WIBJplO6Szmdau9dbleD88u1iiT4GKPqE0R9FOYvvPm1H/w==",
       "dependencies": {
         "@stablelib/chacha20poly1305": "1.0.1",
         "@stablelib/hkdf": "1.0.1",
@@ -2154,7 +2154,7 @@
         "@walletconnect/relay-api": "^1.0.9",
         "@walletconnect/safe-json": "^1.0.2",
         "@walletconnect/time": "^1.0.2",
-        "@walletconnect/types": "2.10.5",
+        "@walletconnect/types": "2.10.6",
         "@walletconnect/window-getters": "^1.0.1",
         "@walletconnect/window-metadata": "^1.0.1",
         "detect-browser": "5.3.0",
@@ -7046,7 +7046,7 @@
       "dependencies": {
         "@noble/ed25519": "^1.7.3",
         "@walletconnect/cacao": "1.0.2",
-        "@walletconnect/core": "^2.10.5",
+        "@walletconnect/core": "^2.10.6",
         "@walletconnect/did-jwt": "2.0.1",
         "@walletconnect/identity-keys": "^1.0.1",
         "@walletconnect/jsonrpc-utils": "1.0.7",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -34,7 +34,7 @@
     "@walletconnect/cacao": "1.0.2",
     "@walletconnect/core": "^2.10.5",
     "@walletconnect/did-jwt": "2.0.1",
-    "@walletconnect/identity-keys": "^1.0.0",
+    "@walletconnect/identity-keys": "^1.0.1",
     "@walletconnect/jsonrpc-utils": "1.0.7",
     "@walletconnect/time": "1.0.2",
     "@walletconnect/utils": "^2.10.5",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@noble/ed25519": "^1.7.3",
     "@walletconnect/cacao": "1.0.2",
-    "@walletconnect/core": "^2.10.5",
+    "@walletconnect/core": "^2.10.6",
     "@walletconnect/did-jwt": "2.0.1",
     "@walletconnect/identity-keys": "^1.0.1",
     "@walletconnect/jsonrpc-utils": "1.0.7",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -34,7 +34,7 @@
     "@walletconnect/cacao": "1.0.2",
     "@walletconnect/core": "^2.10.5",
     "@walletconnect/did-jwt": "2.0.1",
-    "@walletconnect/identity-keys": "^0.2.3",
+    "@walletconnect/identity-keys": "^1.0.0",
     "@walletconnect/jsonrpc-utils": "1.0.7",
     "@walletconnect/time": "1.0.2",
     "@walletconnect/utils": "^2.10.5",

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -34,7 +34,7 @@ export class NotifyClient extends INotifyClient {
   public subscriptions: INotifyClient["subscriptions"];
   public messages: INotifyClient["messages"];
   public watchedAccounts: INotifyClient["watchedAccounts"];
-  public signedStatements: INotifyClient["signedStatements"];
+  public registrationData: INotifyClient["registrationData"];
   public identityKeys: INotifyClient["identityKeys"];
 
   static async init(opts: NotifyClientTypes.ClientOptions) {
@@ -64,7 +64,7 @@ export class NotifyClient extends INotifyClient {
 
     this.logger = generateChildLogger(logger, this.name);
 
-    this.signedStatements = new Store(
+    this.registrationData = new Store(
       this.core,
       this.logger,
       "signedStatements",
@@ -245,7 +245,7 @@ export class NotifyClient extends INotifyClient {
       await this.core.start();
       await this.subscriptions.init();
       await this.messages.init();
-      await this.signedStatements.init();
+      await this.registrationData.init();
       await this.identityKeys.init();
       await this.watchedAccounts.init();
       await this.engine.init();

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -177,14 +177,16 @@ export class NotifyClient extends INotifyClient {
     }
   };
 
-  public prepareRegistration: INotifyClient["prepareRegistration"] = (params) => {
+  public prepareRegistration: INotifyClient["prepareRegistration"] = (
+    params
+  ) => {
     try {
       return this.engine.prepareRegistration(params);
     } catch (error: any) {
       this.logger.error(error.message);
       throw error;
     }
-  }
+  };
 
   public isRegistered: INotifyClient["isRegistered"] = (params) => {
     try {
@@ -193,7 +195,7 @@ export class NotifyClient extends INotifyClient {
       this.logger.error(error.message);
       throw error;
     }
-  }
+  };
 
   public register: INotifyClient["register"] = async (params) => {
     try {

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -177,6 +177,24 @@ export class NotifyClient extends INotifyClient {
     }
   };
 
+  public prepareRegistration: INotifyClient["prepareRegistration"] = (params) => {
+    try {
+      return this.engine.prepareRegistration(params);
+    } catch (error: any) {
+      this.logger.error(error.message);
+      throw error;
+    }
+  }
+
+  public isRegistered: INotifyClient["isRegistered"] = (params) => {
+    try {
+      return this.engine.isRegistered(params);
+    } catch (error: any) {
+      this.logger.error(error.message);
+      throw error;
+    }
+  }
+
   public register: INotifyClient["register"] = async (params) => {
     try {
       return await this.engine.register(params);

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -109,10 +109,7 @@ export class NotifyEngine extends INotifyEngine {
       NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS;
 
     const domain = registerParams.cacaoPayload.domain;
-    const account = registerParams.cacaoPayload.iss
-      .split(":")
-      .slice(-3)
-      .join(":");
+    const account = getCaip10FromDidPkh(registerParams.cacaoPayload.iss)
 
     try {
       await this.watchSubscriptions(account, domain, allApps);
@@ -190,8 +187,11 @@ export class NotifyEngine extends INotifyEngine {
   }) => {
     this.isInitialized();
 
+    // Not using `this.isRegistered` because that accounts for stale
+    // statements, and we don't want stale statements to block users
+    // from subscribing.
     if (!this.client.identityKeys.isRegistered(account)) {
-      throw new Error(`Account ${account} is not registered`);
+      throw new Error(`Account ${account} is not registered.`);
     }
 
     const dappUrl = getDappUrl(appDomain);
@@ -1270,10 +1270,7 @@ export class NotifyEngine extends INotifyEngine {
     signature,
     registerParams,
   }) => {
-    const accountId = registerParams.cacaoPayload.iss
-      .split(":")
-      .slice(-3)
-      .join(":");
+    const accountId = getCaip10FromDidPkh(registerParams.cacaoPayload.iss)
 
     const allApps =
       registerParams.cacaoPayload.statement ===

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -69,10 +69,9 @@ export class NotifyEngine extends INotifyEngine {
     // Explicitly check if it was set to false because null/undefined should count as
     // as "true" since by default it should be limited. The default of `isLimited` is
     // true.
-    const statement =
-      allApps
-        ? NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS
-        : NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN;
+    const statement = allApps
+      ? NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS
+      : NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN;
 
     const prepared = await this.client.identityKeys.prepareRegistration({
       accountId: account,
@@ -194,8 +193,8 @@ export class NotifyEngine extends INotifyEngine {
   }) => {
     this.isInitialized();
 
-    if(!this.client.identityKeys.isRegistered(account)) {
-      throw new Error(`Account ${account} is not registered`)
+    if (!this.client.identityKeys.isRegistered(account)) {
+      throw new Error(`Account ${account} is not registered`);
     }
 
     const dappUrl = getDappUrl(appDomain);
@@ -1279,18 +1278,21 @@ export class NotifyEngine extends INotifyEngine {
       .slice(-3)
       .join(":");
 
-    const allApps = registerParams.cacaoPayload.statement === NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS
+    const allApps =
+      registerParams.cacaoPayload.statement ===
+      NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS;
 
     if (this.client.identityKeys.isRegistered(accountId)) {
-      const hasStaleStatement = 
-        this.checkIfSignedStatementIsStale(
-          accountId,
-          allApps?
-	    NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS :
-	    NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN
-        )
+      const hasStaleStatement = this.checkIfSignedStatementIsStale(
+        accountId,
+        allApps
+          ? NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS
+          : NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN
+      );
       if (hasStaleStatement) {
-	throw new Error("Failed to register, user has an existing stale identity. Unregister using the unregister method.")
+        throw new Error(
+          "Failed to register, user has an existing stale identity. Unregister using the unregister method."
+        );
       }
     }
 

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1307,7 +1307,7 @@ export class NotifyEngine extends INotifyEngine {
       );
     }
 
-    this.client.signedStatements.set(accountId, {
+    this.client.registrationData.set(accountId, {
       account: accountId,
       domain,
       statement,
@@ -1441,7 +1441,7 @@ export class NotifyEngine extends INotifyEngine {
     domain: string
   ) => {
     const hasSignedStatement =
-      this.client.signedStatements.keys.includes(account);
+      this.client.registrationData.keys.includes(account);
     if (!hasSignedStatement) {
       // if there is no signed statement, then this account's statement was signed
       // previous to this function (and thus the latest statement) being introduced
@@ -1449,7 +1449,7 @@ export class NotifyEngine extends INotifyEngine {
       return true;
     }
 
-    const signedStatement = this.client.signedStatements.get(account);
+    const signedStatement = this.client.registrationData.get(account);
 
     return (
       signedStatement.statement !== currentStatement ||

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -106,7 +106,7 @@ export class NotifyEngine extends INotifyEngine {
 
     const allApps =
       registerParams.cacaoPayload.statement ===
-      NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS
+      NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS;
 
     const domain = registerParams.cacaoPayload.domain;
     const account = registerParams.cacaoPayload.iss

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -61,19 +61,26 @@ export class NotifyEngine extends INotifyEngine {
 
   // ---------- Public --------------------------------------- //
 
-  public register: INotifyEngine["register"] = async ({
+  public prepareRegistration: INotifyEngine["prepareRegistration"] = ({
     account,
-    isLimited,
-    onSign,
     domain,
+    allApps
   }) => {
     // Explicitly check if it was set to false because null/undefined should count as
     // as "true" since by default it should be limited. The default of `isLimited` is
     // true.
     const statement =
-      isLimited === false
+      allApps === false
         ? NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS
         : NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN;
+
+    
+  }
+
+  public register: INotifyEngine["register"] = async ({
+    registerParams,
+    signature
+  }) => {
 
     // Retrieve existing identity or register a new one for this account on this device.
     const identity = await this.registerIdentity(

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -71,15 +71,14 @@ export class NotifyEngine extends INotifyEngine {
       ? NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS
       : NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN;
 
-    const prepared = await this.client.identityKeys.prepareRegistration({
+    return this.client.identityKeys.prepareRegistration({
       accountId: account,
       domain,
       statement,
     });
-
-    return prepared;
   };
 
+  // Checks if user is registered and has up to date registration data.
   public isRegistered: INotifyEngine["isRegistered"] = ({
     account,
     allApps,
@@ -94,6 +93,7 @@ export class NotifyEngine extends INotifyEngine {
         domain
       );
     }
+
     return false;
   };
 

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -83,7 +83,7 @@ export class NotifyEngine extends INotifyEngine {
   public isRegistered: INotifyEngine["isRegistered"] = ({
     account,
     allApps,
-    domain
+    domain,
   }) => {
     if (this.client.identityKeys.isRegistered(account)) {
       return !this.checkIfIdentityIsStale(
@@ -91,7 +91,7 @@ export class NotifyEngine extends INotifyEngine {
         allApps
           ? NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS
           : NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN,
-	domain
+        domain
       );
     }
     return false;
@@ -1285,7 +1285,7 @@ export class NotifyEngine extends INotifyEngine {
         allApps
           ? NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS
           : NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN,
-	registerParams.cacaoPayload.domain
+        registerParams.cacaoPayload.domain
       );
       if (hasStaleStatement) {
         throw new Error(
@@ -1309,7 +1309,7 @@ export class NotifyEngine extends INotifyEngine {
 
     this.client.signedStatements.set(accountId, {
       account: accountId,
-      domain, 
+      domain,
       statement,
     });
 
@@ -1451,7 +1451,10 @@ export class NotifyEngine extends INotifyEngine {
 
     const signedStatement = this.client.signedStatements.get(account);
 
-    return signedStatement.statement !== currentStatement || signedStatement.domain !== domain;
+    return (
+      signedStatement.statement !== currentStatement ||
+      signedStatement.domain !== domain
+    );
   };
 
   private watchLastWatchedAccountIfExists = async () => {

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -109,7 +109,7 @@ export class NotifyEngine extends INotifyEngine {
       NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS;
 
     const domain = registerParams.cacaoPayload.domain;
-    const account = getCaip10FromDidPkh(registerParams.cacaoPayload.iss)
+    const account = getCaip10FromDidPkh(registerParams.cacaoPayload.iss);
 
     try {
       await this.watchSubscriptions(account, domain, allApps);
@@ -1270,7 +1270,7 @@ export class NotifyEngine extends INotifyEngine {
     signature,
     registerParams,
   }) => {
-    const accountId = getCaip10FromDidPkh(registerParams.cacaoPayload.iss)
+    const accountId = getCaip10FromDidPkh(registerParams.cacaoPayload.iss);
 
     const allApps =
       registerParams.cacaoPayload.statement ===

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -34,6 +34,7 @@ import {
   NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN,
 } from "../constants";
 import { INotifyEngine, JsonRpcTypes, NotifyClientTypes } from "../types";
+import { getCaip10FromDidPkh } from "../utils/address";
 import { getDappUrl } from "../utils/formats";
 
 export class NotifyEngine extends INotifyEngine {

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -70,7 +70,7 @@ export class NotifyEngine extends INotifyEngine {
     // as "true" since by default it should be limited. The default of `isLimited` is
     // true.
     const statement =
-      allApps === false
+      allApps
         ? NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS
         : NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN;
 
@@ -119,7 +119,7 @@ export class NotifyEngine extends INotifyEngine {
       .join(":");
 
     try {
-      await this.watchSubscriptions(account, domain, isLimited ?? true);
+      await this.watchSubscriptions(account, domain, isLimited);
     } catch (error: any) {
       this.client.logger.error(
         `[Notify] Engine.register > watching subscriptions failed > ${error.message}`

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -260,7 +260,7 @@ export abstract class INotifyClient {
 
   public abstract signedStatements: IStore<
     string,
-    { statement: string; account: string }
+    { statement: string; account: string; domain: string }
   >;
 
   public abstract watchedAccounts: IStore<

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -1,4 +1,4 @@
-import { Cacao } from "@walletconnect/cacao";
+import { Cacao, CacaoPayload } from "@walletconnect/cacao";
 import { IdentityKeys } from "@walletconnect/identity-keys";
 import { ErrorResponse } from "@walletconnect/jsonrpc-utils";
 import { CoreTypes, ICore, IStore, RelayerTypes } from "@walletconnect/types";
@@ -69,8 +69,8 @@ export declare namespace NotifyClientTypes {
   >;
 
   interface NotifyRegistrationParams {
-    payload: Cacao["p"],
-    privateIdentityKey: string
+    cacaoPayload: CacaoPayload;
+    privateIdentityKey: Uint8Array;
   }
 
   interface NotifySubscription {

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -1,3 +1,4 @@
+import { Cacao } from "@walletconnect/cacao";
 import { IdentityKeys } from "@walletconnect/identity-keys";
 import { ErrorResponse } from "@walletconnect/jsonrpc-utils";
 import { CoreTypes, ICore, IStore, RelayerTypes } from "@walletconnect/types";
@@ -66,6 +67,11 @@ export declare namespace NotifyClientTypes {
     string,
     { name: string; id: string; description: string; enabled: boolean }
   >;
+
+  interface NotifyRegistrationParams {
+    payload: Cacao["p"],
+    privateIdentityKey: string
+  }
 
   interface NotifySubscription {
     topic: string;
@@ -281,6 +287,8 @@ export abstract class INotifyClient {
 
   // ---------- Public Methods ------------------------------------------------------- //
 
+  public abstract isRegistered: INotifyEngine["isRegistered"];
+  public abstract prepareRegistration: INotifyEngine["prepareRegistration"];
   public abstract register: INotifyEngine["register"];
   public abstract unregister: INotifyEngine["unregister"];
   public abstract subscribe: INotifyEngine["subscribe"];

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -1,4 +1,4 @@
-import { Cacao, CacaoPayload } from "@walletconnect/cacao";
+import { CacaoPayload } from "@walletconnect/cacao";
 import { IdentityKeys } from "@walletconnect/identity-keys";
 import { ErrorResponse } from "@walletconnect/jsonrpc-utils";
 import { CoreTypes, ICore, IStore, RelayerTypes } from "@walletconnect/types";

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -266,7 +266,7 @@ export abstract class INotifyClient {
   public abstract watchedAccounts: IStore<
     string,
     {
-      isLimited: boolean;
+      allApps: boolean;
       appDomain: string;
       resTopic: string;
       account: string;

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -258,7 +258,7 @@ export abstract class INotifyClient {
     }
   >;
 
-  public abstract signedStatements: IStore<
+  public abstract registrationData: IStore<
     string,
     { statement: string; account: string; domain: string }
   >;

--- a/packages/notify-client/src/types/engine.ts
+++ b/packages/notify-client/src/types/engine.ts
@@ -46,6 +46,7 @@ export abstract class INotifyEngine {
   public abstract isRegistered(params: {
     account: string;
     allApps?: boolean;
+    domain: string
   }): boolean;
 
   public abstract unregister(params: { account: string }): Promise<void>;

--- a/packages/notify-client/src/types/engine.ts
+++ b/packages/notify-client/src/types/engine.ts
@@ -30,21 +30,22 @@ export abstract class INotifyEngine {
   // ---------- Public Methods ------------------------------------------ //
 
   public abstract prepareRegistration(params: {
-    account: string,
-    domain: string,
-    allApps?: boolean
-  }): {
-    registerParams: NotifyClientTypes.NotifyRegistrationParams,
-    message: string
-  };
+    account: string;
+    domain: string;
+    allApps?: boolean;
+  }): Promise<{
+    registerParams: NotifyClientTypes.NotifyRegistrationParams;
+    message: string;
+  }>;
 
   public abstract register(params: {
-    registerParams: NotifyClientTypes.NotifyRegistrationParams,
+    registerParams: NotifyClientTypes.NotifyRegistrationParams;
     signature: string;
   }): Promise<string>;
 
   public abstract isRegistered(params: {
-    account: string
+    account: string;
+    allApps?: boolean;
   }): boolean;
 
   public abstract unregister(params: { account: string }): Promise<void>;

--- a/packages/notify-client/src/types/engine.ts
+++ b/packages/notify-client/src/types/engine.ts
@@ -29,12 +29,23 @@ export abstract class INotifyEngine {
 
   // ---------- Public Methods ------------------------------------------ //
 
+  public abstract prepareRegistration(params: {
+    account: string,
+    domain: string,
+    allApps?: boolean
+  }): {
+    registerParams: NotifyClientTypes.NotifyRegistrationParams,
+    message: string
+  };
+
   public abstract register(params: {
-    account: string;
-    onSign: (message: string) => Promise<string>;
-    isLimited?: boolean;
-    domain: string;
+    registerParams: NotifyClientTypes.NotifyRegistrationParams,
+    signature: string;
   }): Promise<string>;
+
+  public abstract isRegistered(params: {
+    account: string
+  }): boolean;
 
   public abstract unregister(params: { account: string }): Promise<void>;
 

--- a/packages/notify-client/src/types/engine.ts
+++ b/packages/notify-client/src/types/engine.ts
@@ -46,7 +46,7 @@ export abstract class INotifyEngine {
   public abstract isRegistered(params: {
     account: string;
     allApps?: boolean;
-    domain: string
+    domain: string;
   }): boolean;
 
   public abstract unregister(params: { account: string }): Promise<void>;

--- a/packages/notify-client/src/utils/address.ts
+++ b/packages/notify-client/src/utils/address.ts
@@ -1,3 +1,3 @@
-const getCaip10FromDidPkh = (didPkh: string) => {
+export const getCaip10FromDidPkh = (didPkh: string) => {
   return didPkh.split(":").slice(-3).join(":");
 };

--- a/packages/notify-client/src/utils/address.ts
+++ b/packages/notify-client/src/utils/address.ts
@@ -1,0 +1,3 @@
+const getCaip10FromDidPkh = (didPkh: string) => {
+  return didPkh.split(":").slice(-3).join(":");
+};

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -93,7 +93,7 @@ describe("Notify", () => {
           signature: await onSign(preparedRegistration1.message),
         });
 
-        await wallet.signedStatements.set(account, {
+        await wallet.registrationData.set(account, {
           statement: "false statement",
           account,
           domain: testDappMetadata.appDomain,

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -23,6 +23,9 @@ import { encodeEd25519Key, encodeJwt } from "@walletconnect/did-jwt";
 
 const DEFAULT_RELAY_URL = "wss://relay.walletconnect.com";
 
+//@ts-ignore
+global.window = null;
+
 // Comes from notify config from explorer
 // https://explorer-api.walletconnect.com/w3i/v1/notify-config?projectId=228af4798d38a06cb431b473254c9720&appDomain="wc-notify-swift-integration-tests-prod.pages.dev
 const testScopeId = "f173f231-a45c-4dc0-aa5d-956eb04f7360";

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -784,7 +784,7 @@ describe("Notify", () => {
         expect(wallet1.messages.get(subTopic).messages).toEqual({});
       });
 
-      it("correctly handles limited access via `isLimited`", async () => {
+      it("correctly handles limited access via `allApps`", async () => {
         const storageLoc1 = generateClientDbName("notifyTestLimit1");
         const wallet1 = await NotifyClient.init({
           name: "testNotifyClient1",

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -19,7 +19,7 @@ import { disconnectSocket } from "./helpers/ws";
 import axios from "axios";
 import { ICore } from "@walletconnect/types";
 import { generateClientDbName } from "./helpers/storage";
-import { encodeEd25519Key, encodeJwt } from "@walletconnect/did-jwt";
+import { encodeEd25519Key } from "@walletconnect/did-jwt";
 
 const DEFAULT_RELAY_URL = "wss://relay.walletconnect.com";
 
@@ -708,7 +708,7 @@ describe("Notify", () => {
 	const preparedRegistration = await wallet.prepareRegistration({
 	  account,
 	  domain: "hackers.gm.walletconnect.com",
-	  allApps: false
+	  allApps: true
 	})
 
         await wallet2.register({

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -96,10 +96,16 @@ describe("Notify", () => {
         await wallet.signedStatements.set(account, {
           statement: "false statement",
           account,
-	  domain: testDappMetadata.appDomain
+          domain: testDappMetadata.appDomain,
         });
 
-        expect(wallet.isRegistered({ account, allApps: true, domain: testDappMetadata.appDomain })).toEqual(false);
+        expect(
+          wallet.isRegistered({
+            account,
+            allApps: true,
+            domain: testDappMetadata.appDomain,
+          })
+        ).toEqual(false);
 
         const preparedRegistration2 = await wallet.prepareRegistration({
           account,

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -82,18 +82,17 @@ describe("Notify", () => {
 
     describe("register", () => {
       it("can handle stale statements", async () => {
+        const preparedRegistration1 = await wallet.prepareRegistration({
+          account,
+          domain: testDappMetadata.appDomain,
+          allApps: false,
+        });
 
-	const preparedRegistration1 = await wallet.prepareRegistration({
-	  account,
-	  domain: testDappMetadata.appDomain,
-	  allApps: false
-	})
-
-	console.log({preparedRegistration1})
+        console.log({ preparedRegistration1 });
 
         const identityKey1 = await wallet.register({
-	  registerParams: preparedRegistration1.registerParams,
-	  signature: await onSign(preparedRegistration1.message)
+          registerParams: preparedRegistration1.registerParams,
+          signature: await onSign(preparedRegistration1.message),
         });
 
         await wallet.signedStatements.set(account, {
@@ -101,30 +100,36 @@ describe("Notify", () => {
           account,
         });
 
-	expect(wallet.isRegistered({account, allApps: true})).toEqual(false) 
+        expect(wallet.isRegistered({ account, allApps: true })).toEqual(false);
 
-	const preparedRegistration2 = await wallet.prepareRegistration({
-	  account,
-	  domain: testDappMetadata.appDomain,
-	  allApps: false
-	})
+        const preparedRegistration2 = await wallet.prepareRegistration({
+          account,
+          domain: testDappMetadata.appDomain,
+          allApps: false,
+        });
 
-        await expect(wallet.register({
-	  registerParams: preparedRegistration2.registerParams,
-	  signature: await onSign(preparedRegistration2.message)
-        })).rejects.toEqual(new Error("Failed to register, user has an existing stale identity. Unregister using the unregister method."))
+        await expect(
+          wallet.register({
+            registerParams: preparedRegistration2.registerParams,
+            signature: await onSign(preparedRegistration2.message),
+          })
+        ).rejects.toEqual(
+          new Error(
+            "Failed to register, user has an existing stale identity. Unregister using the unregister method."
+          )
+        );
 
-	await wallet.unregister({account})
+        await wallet.unregister({ account });
 
-	const preparedRegistration3 = await wallet.prepareRegistration({
-	  account,
-	  domain: testDappMetadata.appDomain,
-	  allApps: false
-	})
+        const preparedRegistration3 = await wallet.prepareRegistration({
+          account,
+          domain: testDappMetadata.appDomain,
+          allApps: false,
+        });
 
         const identityKey3 = await wallet.register({
-	  registerParams: preparedRegistration3.registerParams,
-	  signature: await onSign(preparedRegistration3.message)
+          registerParams: preparedRegistration3.registerParams,
+          signature: await onSign(preparedRegistration3.message),
         });
 
         expect(identityKey3).to.not.eq(identityKey1);
@@ -151,15 +156,15 @@ describe("Notify", () => {
           projectId,
         });
 
-	const preparedRegistration1 = await newClient.prepareRegistration({
-	  account: newAccount,
-	  domain: testDappMetadata.appDomain,
-	  allApps: true
-	})
+        const preparedRegistration1 = await newClient.prepareRegistration({
+          account: newAccount,
+          domain: testDappMetadata.appDomain,
+          allApps: true,
+        });
 
         const identityKey1 = await newClient.register({
-	  registerParams: preparedRegistration1.registerParams,
-	  signature: await newWallet.signMessage(preparedRegistration1.message)
+          registerParams: preparedRegistration1.registerParams,
+          signature: await newWallet.signMessage(preparedRegistration1.message),
         });
 
         const encodedIdentity = encodeEd25519Key(identityKey1);
@@ -228,15 +233,15 @@ describe("Notify", () => {
           }
         });
 
-	const preparedRegistration = await wallet.prepareRegistration({
-	  account,
-	  domain: testDappMetadata.appDomain,
-	  allApps: true
-	})
+        const preparedRegistration = await wallet.prepareRegistration({
+          account,
+          domain: testDappMetadata.appDomain,
+          allApps: true,
+        });
 
         await wallet.register({
-	  registerParams: preparedRegistration.registerParams,
-	  signature: await onSign(preparedRegistration.message)
+          registerParams: preparedRegistration.registerParams,
+          signature: await onSign(preparedRegistration.message),
         });
 
         await wallet.subscribe({
@@ -434,7 +439,7 @@ describe("Notify", () => {
           wallet.subscriptions.set(`topic${num}`, {
             account: `account${num}`,
             expiry: Date.now(),
-	    appAuthenticationKey: "",
+            appAuthenticationKey: "",
             relay: {
               protocol: RELAYER_DEFAULT_PROTOCOL,
             },
@@ -633,15 +638,15 @@ describe("Notify", () => {
           wallet1ReceivedChangedEvent = true;
         });
 
-	const preparedRegistration = await wallet.prepareRegistration({
-	  account,
-	  domain: testDappMetadata.appDomain,
-	  allApps: false
-	})
+        const preparedRegistration = await wallet.prepareRegistration({
+          account,
+          domain: testDappMetadata.appDomain,
+          allApps: false,
+        });
 
         await wallet.register({
-	  registerParams: preparedRegistration.registerParams,
-	  signature: await onSign(preparedRegistration.message)
+          registerParams: preparedRegistration.registerParams,
+          signature: await onSign(preparedRegistration.message),
         });
 
         await waitForEvent(() => wallet1ReceivedChangedEvent);
@@ -705,15 +710,15 @@ describe("Notify", () => {
           wallet2GotUpdate = true;
         });
 
-	const preparedRegistration = await wallet.prepareRegistration({
-	  account,
-	  domain: "hackers.gm.walletconnect.com",
-	  allApps: true
-	})
+        const preparedRegistration = await wallet.prepareRegistration({
+          account,
+          domain: "hackers.gm.walletconnect.com",
+          allApps: true,
+        });
 
         await wallet2.register({
-	  registerParams: preparedRegistration.registerParams,
-	  signature: await onSign(preparedRegistration.message)
+          registerParams: preparedRegistration.registerParams,
+          signature: await onSign(preparedRegistration.message),
         });
 
         await waitForEvent(() => {
@@ -798,15 +803,15 @@ describe("Notify", () => {
           wallet1ReceivedChangedEvent = true;
         });
 
-	const preparedRegistration = await wallet1.prepareRegistration({
-	  account,
-	  domain: testDappMetadata.appDomain,
-	  allApps: false
-	})
+        const preparedRegistration = await wallet1.prepareRegistration({
+          account,
+          domain: testDappMetadata.appDomain,
+          allApps: false,
+        });
 
         await wallet1.register({
-	  registerParams: preparedRegistration.registerParams,
-	  signature: await onSign(preparedRegistration.message)
+          registerParams: preparedRegistration.registerParams,
+          signature: await onSign(preparedRegistration.message),
         });
 
         await waitForEvent(() => wallet1ReceivedChangedEvent);
@@ -829,15 +834,15 @@ describe("Notify", () => {
           wallet2ReceivedChangedEvent = true;
         });
 
-	const preparedRegistration2 = await wallet2.prepareRegistration({
-	  account,
-	  domain: testDappMetadata.appDomain,
-	  allApps: false
-	})
+        const preparedRegistration2 = await wallet2.prepareRegistration({
+          account,
+          domain: testDappMetadata.appDomain,
+          allApps: false,
+        });
 
         await wallet2.register({
-	  registerParams: preparedRegistration2.registerParams,
-	  signature: await onSign(preparedRegistration2.message)
+          registerParams: preparedRegistration2.registerParams,
+          signature: await onSign(preparedRegistration2.message),
         });
 
         await waitForEvent(() => wallet2ReceivedChangedEvent);
@@ -866,15 +871,15 @@ describe("Notify", () => {
           wallet3ReceivedChangedEvent = true;
         });
 
-	const preparedRegistration3 = await wallet3.prepareRegistration({
-	  account,
-	  domain: "hackers.gm.walletconnect.com",
-	  allApps: false
-	})
+        const preparedRegistration3 = await wallet3.prepareRegistration({
+          account,
+          domain: "hackers.gm.walletconnect.com",
+          allApps: false,
+        });
 
         await wallet3.register({
-	  registerParams: preparedRegistration3.registerParams,
-	  signature: await onSign(preparedRegistration3.message)
+          registerParams: preparedRegistration3.registerParams,
+          signature: await onSign(preparedRegistration3.message),
         });
 
         await waitForEvent(() => wallet3ReceivedChangedEvent);

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -713,7 +713,7 @@ describe("Notify", () => {
           wallet2GotUpdate = true;
         });
 
-        const preparedRegistration = await wallet.prepareRegistration({
+        const preparedRegistration = await wallet2.prepareRegistration({
           account,
           domain: "hackers.gm.walletconnect.com",
           allApps: true,

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -88,8 +88,6 @@ describe("Notify", () => {
           allApps: false,
         });
 
-        console.log({ preparedRegistration1 });
-
         const identityKey1 = await wallet.register({
           registerParams: preparedRegistration1.registerParams,
           signature: await onSign(preparedRegistration1.message),
@@ -538,8 +536,6 @@ describe("Notify", () => {
         await wallet.deleteSubscription({ topic: walletSubscriptionTopic });
 
         await waitForEvent(() => gotNotifySubscriptionsChanged);
-
-        console.log(gotNotifySubscriptionsChangedEvent);
 
         // Check that wallet is in expected state.
         expect(Object.keys(wallet.getActiveSubscriptions()).length).toBe(0);

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -96,9 +96,10 @@ describe("Notify", () => {
         await wallet.signedStatements.set(account, {
           statement: "false statement",
           account,
+	  domain: testDappMetadata.appDomain
         });
 
-        expect(wallet.isRegistered({ account, allApps: true })).toEqual(false);
+        expect(wallet.isRegistered({ account, allApps: true, domain: testDappMetadata.appDomain })).toEqual(false);
 
         const preparedRegistration2 = await wallet.prepareRegistration({
           account,

--- a/packages/notify-client/test/helpers/notify.ts
+++ b/packages/notify-client/test/helpers/notify.ts
@@ -37,13 +37,17 @@ export const createNotifySubscription = async (
     ? gmHackersMetadata.appDomain
     : testDappMetadata.appDomain;
 
-  await wallet.register({
-    domain,
+  const preparedRegistration = await wallet.prepareRegistration({
     account,
-    isLimited: false,
-    onSign,
+    domain: testDappMetadata.appDomain,
+    allApps: true
+  })
+  
+  await wallet.register({
+    registerParams: preparedRegistration.registerParams,
+    signature: await onSign(preparedRegistration.message)
   });
-
+  
   await wallet.subscribe({
     appDomain: domain,
     account,

--- a/packages/notify-client/test/helpers/notify.ts
+++ b/packages/notify-client/test/helpers/notify.ts
@@ -37,10 +37,10 @@ export const createNotifySubscription = async (
     ? gmHackersMetadata.appDomain
     : testDappMetadata.appDomain;
 
-  if (!wallet.isRegistered({ account })) {
+  if (!wallet.isRegistered({ account, domain: testDappMetadata.appDomain })) {
     const preparedRegistration = await wallet.prepareRegistration({
       account,
-      domain,
+      domain: testDappMetadata.appDomain,
       allApps: true,
     });
 

--- a/packages/notify-client/test/helpers/notify.ts
+++ b/packages/notify-client/test/helpers/notify.ts
@@ -37,16 +37,18 @@ export const createNotifySubscription = async (
     ? gmHackersMetadata.appDomain
     : testDappMetadata.appDomain;
 
-  const preparedRegistration = await wallet.prepareRegistration({
-    account,
-    domain: testDappMetadata.appDomain,
-    allApps: true
-  })
+  if(!wallet.isRegistered({account})) {
+    const preparedRegistration = await wallet.prepareRegistration({
+      account,
+      domain, 
+      allApps: true
+    })
   
-  await wallet.register({
-    registerParams: preparedRegistration.registerParams,
-    signature: await onSign(preparedRegistration.message)
-  });
+    await wallet.register({
+      registerParams: preparedRegistration.registerParams,
+      signature: await onSign(preparedRegistration.message)
+    });
+  }
   
   await wallet.subscribe({
     appDomain: domain,

--- a/packages/notify-client/test/helpers/notify.ts
+++ b/packages/notify-client/test/helpers/notify.ts
@@ -37,19 +37,19 @@ export const createNotifySubscription = async (
     ? gmHackersMetadata.appDomain
     : testDappMetadata.appDomain;
 
-  if(!wallet.isRegistered({account})) {
+  if (!wallet.isRegistered({ account })) {
     const preparedRegistration = await wallet.prepareRegistration({
       account,
-      domain, 
-      allApps: true
-    })
-  
+      domain,
+      allApps: true,
+    });
+
     await wallet.register({
       registerParams: preparedRegistration.registerParams,
-      signature: await onSign(preparedRegistration.message)
+      signature: await onSign(preparedRegistration.message),
     });
   }
-  
+
   await wallet.subscribe({
     appDomain: domain,
     account,


### PR DESCRIPTION
>[!NOTE]
> All required PRs have been merged.
# Changes

Per new spec updates [here](https://github.com/WalletConnect/walletconnect-specs/pull/177), [here](https://github.com/WalletConnect/walletconnect-specs/pull/178) , [here](https://github.com/WalletConnect/walletconnect-specs/pull/181), and identity util changes [here](https://github.com/WalletConnect/walletconnect-utils/pull/154), the notify client registration methodology is as follows:

- `register` is now split into two functions :
    - `prepareRegistration`: Actually prepare the registration
    - `register`: Use the prepared registration, as well as a signature of the message from prepped registration, to actually register the identity.
- Addition of new function `isRegistered` to check registration status. 
- Update `checkStatementIsStale` to `checkRegistrationIsStale` since it now also checks against domain.

## Implications of this
- Register now no longer automatically unregisters  accounts that have stale statements. That logic is now handled by the user of the client, via checking `isRegistered`. 
- UIs (I.E Web3Inbox) will have to refactor how they handle signatures completely

## Tested
Tested via updating existing unit tests to use new API.

## Notes
- ~~Won't merge until https://github.com/WalletConnect/walletconnect-specs/pull/181 is merged~~
- Identity keys `1.0.1` is currenty a canary, will go to stable once this is merged. 