### PR TITLE
Feat/notify type image

### DIFF
--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1538,7 +1538,11 @@ export class NotifyEngine extends INotifyEngine {
         return [
           type.id,
           {
-            ...type,
+	    imageId: type.image_id,
+	    imageUrls: type.imageUrls,
+	    description: type.description,
+	    name: type.name,
+	    id: type.id,
             enabled: serverSub.scope.includes(type.id),
           },
         ];

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1538,11 +1538,11 @@ export class NotifyEngine extends INotifyEngine {
         return [
           type.id,
           {
-	    imageId: type.image_id,
-	    imageUrls: type.imageUrls,
-	    description: type.description,
-	    name: type.name,
-	    id: type.id,
+            imageId: type.image_id,
+            imageUrls: type.imageUrls,
+            description: type.description,
+            name: type.name,
+            id: type.id,
             enabled: serverSub.scope.includes(type.id),
           },
         ];

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -1538,7 +1538,6 @@ export class NotifyEngine extends INotifyEngine {
         return [
           type.id,
           {
-            imageId: type.image_id,
             imageUrls: type.imageUrls,
             description: type.description,
             name: type.name,

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -7,6 +7,12 @@ import { Logger } from "pino";
 
 import { INotifyEngine } from "./engine";
 
+interface ImageUrl {
+  sm: string;
+  md: string;
+  lg: string;
+}
+
 export declare namespace NotifyClientTypes {
   type Event =
     | "notify_subscription"
@@ -65,7 +71,7 @@ export declare namespace NotifyClientTypes {
 
   type ScopeMap = Record<
     string,
-    { name: string; id: string; description: string; enabled: boolean }
+    { name: string; id: string; description: string; enabled: boolean, imageId?: string, imageUrls: ImageUrl  }
   >;
 
   interface NotifyRegistrationParams {
@@ -246,6 +252,8 @@ export declare namespace NotifyClientTypes {
     notificationTypes: Array<{
       id: string;
       name: string;
+      imageUrls: ImageUrl;
+      image_id: string;
       description: string;
     }>;
     description: Metadata["description"];

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -71,7 +71,14 @@ export declare namespace NotifyClientTypes {
 
   type ScopeMap = Record<
     string,
-    { name: string; id: string; description: string; enabled: boolean, imageId?: string, imageUrls: ImageUrl  }
+    {
+      name: string;
+      id: string;
+      description: string;
+      enabled: boolean;
+      imageId?: string;
+      imageUrls: ImageUrl;
+    }
   >;
 
   interface NotifyRegistrationParams {

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -97,7 +97,6 @@ export declare namespace NotifyClientTypes {
     title: string;
     body: string;
     id: string;
-    icon: string;
     url: string;
     type?: string;
   }

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -76,7 +76,6 @@ export declare namespace NotifyClientTypes {
       id: string;
       description: string;
       enabled: boolean;
-      imageId?: string;
       imageUrls: ImageUrl;
     }
   >;

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -7,7 +7,7 @@ import { Logger } from "pino";
 
 import { INotifyEngine } from "./engine";
 
-interface ImageUrl {
+interface ImageUrls {
   sm: string;
   md: string;
   lg: string;
@@ -76,7 +76,7 @@ export declare namespace NotifyClientTypes {
       id: string;
       description: string;
       enabled: boolean;
-      imageUrls: ImageUrl;
+      imageUrls: ImageUrls;
     }
   >;
 
@@ -258,7 +258,7 @@ export declare namespace NotifyClientTypes {
     notificationTypes: Array<{
       id: string;
       name: string;
-      imageUrls: ImageUrl;
+      imageUrls: ImageUrls;
       image_id: string;
       description: string;
     }>;

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -540,6 +540,26 @@ describe("Notify", () => {
       });
     });
 
+    describe("Notification type images", () => {
+      it("fetches notification type images", async () => {
+        await createNotifySubscription(wallet, account, onSign);
+
+        expect(wallet.subscriptions.keys.length).toBe(1);
+
+        const subscription = wallet.subscriptions.getAll()[0];
+
+	const scope = Object.entries(subscription.scope)[0][1]
+
+	const expectedImageSmUrlRegex = /.*\/w3i\/v1\/logo\/sm\/.*/g
+	const expectedImageMdUrlRegex = /.*\/w3i\/v1\/logo\/md\/.*/g
+	const expectedImageLgUrlRegex = /.*\/w3i\/v1\/logo\/lg\/.*/g
+
+	expect(scope.imageUrls.sm).toMatch(expectedImageSmUrlRegex)
+	expect(scope.imageUrls.md).toMatch(expectedImageMdUrlRegex)
+	expect(scope.imageUrls.lg).toMatch(expectedImageLgUrlRegex)
+      })
+    })
+
     describe("watchSubscriptions", () => {
       it("fires correct event update", async () => {
         let updateEvent: any = {};

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -548,17 +548,17 @@ describe("Notify", () => {
 
         const subscription = wallet.subscriptions.getAll()[0];
 
-	const scope = Object.entries(subscription.scope)[0][1]
+        const scope = Object.entries(subscription.scope)[0][1];
 
-	const expectedImageSmUrlRegex = /.*\/w3i\/v1\/logo\/sm\/.*/g
-	const expectedImageMdUrlRegex = /.*\/w3i\/v1\/logo\/md\/.*/g
-	const expectedImageLgUrlRegex = /.*\/w3i\/v1\/logo\/lg\/.*/g
+        const expectedImageSmUrlRegex = /.*\/w3i\/v1\/logo\/sm\/.*/g;
+        const expectedImageMdUrlRegex = /.*\/w3i\/v1\/logo\/md\/.*/g;
+        const expectedImageLgUrlRegex = /.*\/w3i\/v1\/logo\/lg\/.*/g;
 
-	expect(scope.imageUrls.sm).toMatch(expectedImageSmUrlRegex)
-	expect(scope.imageUrls.md).toMatch(expectedImageMdUrlRegex)
-	expect(scope.imageUrls.lg).toMatch(expectedImageLgUrlRegex)
-      })
-    })
+        expect(scope.imageUrls.sm).toMatch(expectedImageSmUrlRegex);
+        expect(scope.imageUrls.md).toMatch(expectedImageMdUrlRegex);
+        expect(scope.imageUrls.lg).toMatch(expectedImageLgUrlRegex);
+      });
+    });
 
     describe("watchSubscriptions", () => {
       it("fires correct event update", async () => {


### PR DESCRIPTION
# Description
- Remove `icon` property from notification
- Expose `imageUrls` coming from cloud config
- test: Add unit test to ensure we get the images

# Issue
Resolves #84 (Issue links to slack thread with more context)

# Note
A Doc PR will need to follow this one to recommend getting the images from the scopes rather than the `icon` prop

~~Spec PR: https://github.com/WalletConnect/walletconnect-specs/pull/188 ;; not merging this until~~ **spec PR is merged.**

