### PR TITLE
feat: pass is verified from notify config object to subs metadata

### DIFF
--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -999,6 +999,7 @@ export class NotifyEngine extends INotifyEngine {
             ? Object.values(notifyConfig.image_url)
             : [],
           appDomain: sub.appDomain,
+          isVerified: notifyConfig?.isVerified ?? false,
         },
         relay: {
           protocol: RELAYER_DEFAULT_PROTOCOL,

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -60,6 +60,7 @@ export declare namespace NotifyClientTypes {
     description: string;
     icons: string[];
     appDomain: string;
+    isVerified: boolean;
   }
 
   type ScopeMap = Record<
@@ -229,6 +230,7 @@ export declare namespace NotifyClientTypes {
       md: string;
       lg: string;
     };
+    isVerified: boolean;
   }
 }
 


### PR DESCRIPTION
# Changes

On the w3i app, we filter the projects with the app domain and get the verification status to do conditional rendering for unapproved/dev mode projects. This will help us get rid of extra logic on the UI. Added `isVerified` field to `metadata` of the subscription object. 