### PR TITLE
Feat/get notifications history

### DIFF
--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -135,15 +135,6 @@ export class NotifyClient extends INotifyClient {
     }
   };
 
-  public getMessageHistory: INotifyClient["getMessageHistory"] = (params) => {
-    try {
-      return this.engine.getMessageHistory(params);
-    } catch (error: any) {
-      this.logger.error(error.message);
-      throw error;
-    }
-  };
-
   public deleteNotifyMessage: INotifyClient["deleteNotifyMessage"] = (
     params
   ) => {

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -135,11 +135,11 @@ export class NotifyClient extends INotifyClient {
     }
   };
 
-  public deleteNotifyMessage: INotifyClient["deleteNotifyMessage"] = (
+  public getNotificationHistory: INotifyClient["getNotificationHistory"] = (
     params
   ) => {
     try {
-      return this.engine.deleteNotifyMessage(params);
+      return this.engine.getNotificationHistory(params);
     } catch (error: any) {
       this.logger.error(error.message);
       throw error;

--- a/packages/notify-client/src/constants/engine.ts
+++ b/packages/notify-client/src/constants/engine.ts
@@ -72,5 +72,16 @@ export const ENGINE_RPC_OPTS: Record<JsonRpcTypes.WcMethod, RpcOpts> = {
       ttl: FIVE_MINUTES,
       tag: 4013,
     },
+
   },
+ wc_notifyGetNotifications: {
+    req: {
+      ttl: FIVE_MINUTES,
+      tag: 4014,
+    },
+    res: {
+      ttl: FIVE_MINUTES,
+      tag: 4015,
+    },
+  }
 };

--- a/packages/notify-client/src/constants/engine.ts
+++ b/packages/notify-client/src/constants/engine.ts
@@ -72,9 +72,8 @@ export const ENGINE_RPC_OPTS: Record<JsonRpcTypes.WcMethod, RpcOpts> = {
       ttl: FIVE_MINUTES,
       tag: 4013,
     },
-
   },
- wc_notifyGetNotifications: {
+  wc_notifyGetNotifications: {
     req: {
       ttl: FIVE_MINUTES,
       tag: 4014,
@@ -83,5 +82,5 @@ export const ENGINE_RPC_OPTS: Record<JsonRpcTypes.WcMethod, RpcOpts> = {
       ttl: FIVE_MINUTES,
       tag: 4015,
     },
-  }
+  },
 };

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -15,7 +15,6 @@ import {
   isJsonRpcResponse,
   isJsonRpcResult,
 } from "@walletconnect/jsonrpc-utils";
-import { FIVE_MINUTES } from "@walletconnect/time";
 import { JsonRpcRecord, RelayerTypes } from "@walletconnect/types";
 import {
   TYPE_1,
@@ -391,9 +390,9 @@ export class NotifyEngine extends INotifyEngine {
 
         // Add timeout to prevent memory leaks with undying promises
         setTimeout(() => {
-          reject("getNotificationHistory timed out waiting for a response");
+          reject(new Error("getNotificationHistory timed out waiting for a response"));
           // Using five minutes as it is the TTL of wc_getNotificationHistory
-        }, FIVE_MINUTES);
+        }, 300 * 1000);
 
         this.sendRequest(topic, "wc_notifyGetNotifications", { auth });
       });

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -375,16 +375,6 @@ export class NotifyEngine extends INotifyEngine {
     }
   };
 
-  public getMessageHistory: INotifyEngine["getMessageHistory"] = ({
-    topic,
-  }) => {
-    this.isInitialized();
-
-    return this.client.messages.keys.includes(topic)
-      ? this.client.messages.get(topic).messages
-      : {};
-  };
-
   public deleteSubscription: INotifyEngine["deleteSubscription"] = async ({
     topic,
   }) => {

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -351,7 +351,7 @@ export class NotifyEngine extends INotifyEngine {
 
       const issuedAt = Math.round(Date.now() / 1000);
       const expiry =
-        issuedAt + ENGINE_RPC_OPTS["wc_notifyGetNotifications"].res.ttl;
+        issuedAt + ENGINE_RPC_OPTS["wc_notifyGetNotifications"].req.ttl;
 
       const cachedKey = this.getCachedDappKey(subscription);
       const dappUrl = getDappUrl(subscription.metadata.appDomain);
@@ -389,7 +389,7 @@ export class NotifyEngine extends INotifyEngine {
           }
         });
 
-        // Add timeout to prevent memory leaks with undying promises
+        // Add timeout to prevent memory leaks with unresolving promises
         setTimeout(() => {
           reject(
             new Error("getNotificationHistory timed out waiting for a response")

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -15,6 +15,7 @@ import {
   isJsonRpcResponse,
   isJsonRpcResult,
 } from "@walletconnect/jsonrpc-utils";
+import { FIVE_MINUTES } from "@walletconnect/time";
 import { JsonRpcRecord, RelayerTypes } from "@walletconnect/types";
 import {
   TYPE_1,
@@ -394,7 +395,8 @@ export class NotifyEngine extends INotifyEngine {
             new Error("getNotificationHistory timed out waiting for a response")
           );
           // Using five minutes as it is the TTL of wc_getNotificationHistory
-        }, 300 * 1000);
+          // The FIVE_MINUTES const is in seconds, not ms.
+        }, FIVE_MINUTES * 1000);
 
         this.sendRequest(topic, "wc_notifyGetNotifications", { auth });
       });

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -368,10 +368,10 @@ export class NotifyEngine extends INotifyEngine {
           sub: composeDidPkh(subscription.account),
           iat: issuedAt,
           exp: expiry,
-	  aud: encodeEd25519Key(dappIdentityKey),
+          aud: encodeEd25519Key(dappIdentityKey),
           app: `${DID_WEB_PREFIX}${subscription.metadata.appDomain}`,
           lmt: limit ?? 50,
-	  // TODO: adapt to unread capabilities when available on Notify server
+          // TODO: adapt to unread capabilities when available on Notify server
           urf: false,
         };
 
@@ -389,10 +389,10 @@ export class NotifyEngine extends INotifyEngine {
           }
         });
 
-	// Add timeout to prevent memory leaks with undying promises
+        // Add timeout to prevent memory leaks with undying promises
         setTimeout(() => {
           reject("getNotificationHistory timed out waiting for a response");
-	// Using five minutes as it is the TTL of wc_getNotificationHistory
+          // Using five minutes as it is the TTL of wc_getNotificationHistory
         }, FIVE_MINUTES);
 
         this.sendRequest(topic, "wc_notifyGetNotifications", { auth });
@@ -485,7 +485,6 @@ export class NotifyEngine extends INotifyEngine {
 
     return Object.fromEntries(subscriptions);
   };
-
 
   // ---------- Protected Helpers --------------------------------------- //
   protected sendRequest: INotifyEngine["sendRequest"] = async (

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -818,18 +818,17 @@ export class NotifyEngine extends INotifyEngine {
 
   protected onNotifyGetNotificationsResponse: INotifyEngine["onNotifyGetNotificationsResponse"] =
     async (topic, payload) => {
-      console.log("GOT RESPONSE")
       if (isJsonRpcResult(payload)) {
         this.client.logger.info(
           "[Notify] Engine.onNotifyGetNotificationsResponse > result:",
           topic,
           payload
         );
-	const claims =
-	  this.decodeAndValidateJwtAuth<NotifyClientTypes.GetNotificationsResponseClaims>(
-	    payload.result.auth,
-	    "notify_get_notifications_response"
-	  )
+        const claims =
+          this.decodeAndValidateJwtAuth<NotifyClientTypes.GetNotificationsResponseClaims>(
+            payload.result.auth,
+            "notify_get_notifications_response"
+          );
 
         this.emit("notify_get_notifications_response", {
           hasMore: claims.mre ?? false,
@@ -838,7 +837,6 @@ export class NotifyEngine extends INotifyEngine {
           notifications: claims.nfs,
         });
       } else if (isJsonRpcError(payload)) {
-      console.log("IT'S AN ERROR")
         this.client.logger.error(
           "[Notify] Engine.onNotifyGetNotificationsResponse  > error:",
           topic,
@@ -846,7 +844,6 @@ export class NotifyEngine extends INotifyEngine {
         );
       }
     };
-
 
   protected onNotifyWatchSubscriptionsResponse: INotifyEngine["onNotifyWatchSubscriptionsResponse"] =
     async (topic, payload) => {

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -423,8 +423,8 @@ export class NotifyEngine extends INotifyEngine {
     return Object.fromEntries(subscriptions);
   };
 
-  // ---------- Protected Helpers --------------------------------------- //
 
+  // ---------- Protected Helpers --------------------------------------- //
   protected sendRequest: INotifyEngine["sendRequest"] = async (
     topic,
     method,
@@ -849,6 +849,24 @@ export class NotifyEngine extends INotifyEngine {
         });
       }
     };
+
+  // ---------- Relay Event Forwarding ------------------------------- //
+
+  protected on: INotifyEngine["on"] = (name, listener) => {
+    return this.client.events.on(name, listener);
+  };
+
+  protected once: INotifyEngine["once"] = (name, listener) => {
+    return this.client.events.once(name, listener);
+  };
+
+  protected off: INotifyEngine["off"] = (name, listener) => {
+    return this.client.events.off(name, listener);
+  };
+
+  protected emit: INotifyEngine["emit"] = (name, args) => {
+    return this.client.events.emit(name, args);
+  };
 
   // ---------- Private Helpers --------------------------------- //
 

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -848,9 +848,9 @@ export class NotifyEngine extends INotifyEngine {
           payload.error
         );
 
-	this.emit("notify_get_notifications_response", {
-	  error: payload.error.message
-	})
+        this.emit("notify_get_notifications_response", {
+          error: payload.error.message,
+        });
       }
     };
 

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -390,7 +390,9 @@ export class NotifyEngine extends INotifyEngine {
 
         // Add timeout to prevent memory leaks with undying promises
         setTimeout(() => {
-          reject(new Error("getNotificationHistory timed out waiting for a response"));
+          reject(
+            new Error("getNotificationHistory timed out waiting for a response")
+          );
           // Using five minutes as it is the TTL of wc_getNotificationHistory
         }, 300 * 1000);
 

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -341,6 +341,10 @@ export class NotifyEngine extends INotifyEngine {
     async ({ topic, limit, startingAfter }) => {
       this.isInitialized();
 
+      if (!this.client.subscriptions.keys.includes(topic)) {
+        throw new Error(`No subscription with topic ${topic} exists`);
+      }
+
       const subscription = this.client.subscriptions.get(topic);
 
       const identityKey = encodeEd25519Key(

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -384,7 +384,7 @@ export class NotifyEngine extends INotifyEngine {
           if (args.error === null) {
             resolve(args);
           } else {
-            reject(args.error);
+            reject(new Error(args.error));
           }
         });
 
@@ -637,6 +637,8 @@ export class NotifyEngine extends INotifyEngine {
           return this.onNotifyUpdateResponse(topic, payload);
         case "wc_notifyWatchSubscription":
           return this.onNotifyWatchSubscriptionsResponse(topic, payload);
+        case "wc_notifyGetNotifications":
+          return this.onNotifyGetNotificationsResponse(topic, payload);
         default:
           return this.client.logger.info(
             `[Notify] Unsupported response method ${resMethod}`

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -847,6 +847,10 @@ export class NotifyEngine extends INotifyEngine {
           topic,
           payload.error
         );
+
+	this.emit("notify_get_notifications_response", {
+	  error: payload.error.message
+	})
       }
     };
 

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -816,6 +816,38 @@ export class NotifyEngine extends INotifyEngine {
       }
     };
 
+  protected onNotifyGetNotificationsResponse: INotifyEngine["onNotifyGetNotificationsResponse"] =
+    async (topic, payload) => {
+      console.log("GOT RESPONSE")
+      if (isJsonRpcResult(payload)) {
+        this.client.logger.info(
+          "[Notify] Engine.onNotifyGetNotificationsResponse > result:",
+          topic,
+          payload
+        );
+	const claims =
+	  this.decodeAndValidateJwtAuth<NotifyClientTypes.GetNotificationsResponseClaims>(
+	    payload.result.auth,
+	    "notify_get_notifications_response"
+	  )
+
+        this.emit("notify_get_notifications_response", {
+          hasMore: claims.mre ?? false,
+          hasMoreUnread: claims.mur ?? false,
+          error: null,
+          notifications: claims.nfs,
+        });
+      } else if (isJsonRpcError(payload)) {
+      console.log("IT'S AN ERROR")
+        this.client.logger.error(
+          "[Notify] Engine.onNotifyGetNotificationsResponse  > error:",
+          topic,
+          payload.error
+        );
+      }
+    };
+
+
   protected onNotifyWatchSubscriptionsResponse: INotifyEngine["onNotifyWatchSubscriptionsResponse"] =
     async (topic, payload) => {
       this.client.logger.info(

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -205,7 +205,7 @@ export declare namespace NotifyClientTypes {
     aud: string; // did:key of client identity key
     mur: boolean; // more unread
     mre: boolean; // more pages
-    nfs: NotifyMessage[]
+    nfs: NotifyMessage[];
   }
 
   interface NotifyWatchSubscriptionsResponseClaims extends BaseJwtClaims {

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -109,6 +109,17 @@ export declare namespace NotifyClientTypes {
     publishedAt: number;
   }
 
+  interface GetNotificationsJwtClaims extends BaseJwtClaims {
+    act: "notify_get_notifications";
+    sub: string; // did:pkh of blockchain account that this notify subscription is associated with
+    aud: string; // did:key of client identity key
+    iss: string; // did:key of an identity key. Enables to resolve attached blockchain account.
+    app: string; // did web domain url,
+    urf: boolean; // unread first
+    lmt: number; // max number of notifications
+    aft: string | null; // notification to start returning messages after,
+  }
+
   interface SubscriptionJWTClaims extends BaseJwtClaims {
     act: "notify_subscription"; // action intent (must be "notify_subscription")
     iss: string; // did:key of client identity key
@@ -186,6 +197,15 @@ export declare namespace NotifyClientTypes {
 
   interface DeleteResponseJWTClaims extends CommonResponseJWTClaims {
     act: "notify_delete_response";
+  }
+
+  interface GetNotificationsResponseClaims extends BaseJwtClaims {
+    act: "notify_get_notifications_response";
+    iss: string; // did:key of notify server identity key
+    aud: string; // did:key of client identity key
+    mur: boolean; // more unread
+    mre: boolean; // more pages
+    nfs: NotifyMessage[]
   }
 
   interface NotifyWatchSubscriptionsResponseClaims extends BaseJwtClaims {

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -315,7 +315,6 @@ export abstract class INotifyClient {
   public abstract update: INotifyEngine["update"];
   public abstract decryptMessage: INotifyEngine["decryptMessage"];
   public abstract getNotificationHistory: INotifyEngine["getNotificationHistory"];
-  public abstract deleteNotifyMessage: INotifyEngine["deleteNotifyMessage"];
   public abstract getActiveSubscriptions: INotifyEngine["getActiveSubscriptions"];
   public abstract deleteSubscription: INotifyEngine["deleteSubscription"];
 

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -294,7 +294,7 @@ export abstract class INotifyClient {
   public abstract subscribe: INotifyEngine["subscribe"];
   public abstract update: INotifyEngine["update"];
   public abstract decryptMessage: INotifyEngine["decryptMessage"];
-  public abstract getMessageHistory: INotifyEngine["getMessageHistory"];
+  public abstract getNotificationHistory: INotifyEngine["getNotificationHistory"];
   public abstract deleteNotifyMessage: INotifyEngine["deleteNotifyMessage"];
   public abstract getActiveSubscriptions: INotifyEngine["getActiveSubscriptions"];
   public abstract deleteSubscription: INotifyEngine["deleteSubscription"];

--- a/packages/notify-client/src/types/engine.ts
+++ b/packages/notify-client/src/types/engine.ts
@@ -83,11 +83,6 @@ export abstract class INotifyEngine {
     encryptedMessage: string;
   }): Promise<NotifyClientTypes.NotifyMessage>;
 
-  // get all messages for a subscription
-  public abstract getMessageHistory(params: {
-    topic: string;
-  }): Record<number, NotifyClientTypes.NotifyMessageRecord>;
-
   // delete active subscription
   public abstract deleteSubscription(params: { topic: string }): Promise<void>;
 

--- a/packages/notify-client/src/types/engine.ts
+++ b/packages/notify-client/src/types/engine.ts
@@ -21,12 +21,13 @@ export declare namespace NotifyEngineTypes {
     publishedAt: number;
   }
 
-  type EventResponseOrError<T> = (T & {error: null}) | {
-    error: string
-  }
+  type EventResponseOrError<T> =
+    | (T & { error: null })
+    | {
+        error: string;
+      };
 
-  type Event =
-    | "notify_get_notifications_response"
+  type Event = "notify_get_notifications_response";
 
   interface EventArguments {
     notify_get_notifications_response: EventResponseOrError<{

--- a/packages/notify-client/src/types/engine.ts
+++ b/packages/notify-client/src/types/engine.ts
@@ -8,6 +8,7 @@ import {
 import { CryptoTypes } from "@walletconnect/types";
 import { INotifyClient, NotifyClientTypes } from "./client";
 import { JsonRpcTypes } from "./jsonrpc";
+import EventEmitter from "events";
 
 export interface RpcOpts {
   req: { ttl: number; tag: number };
@@ -195,4 +196,24 @@ export abstract class INotifyEngine {
       | JsonRpcResult<JsonRpcTypes.Results["wc_notifyGetNotifications"]>
       | JsonRpcError
   ): Promise<void>;
+
+  protected abstract on: <E extends NotifyEngineTypes.Event>(
+    event: E,
+    listener: (args: NotifyEngineTypes.EventArguments[E]) => void
+  ) => EventEmitter;
+
+  protected abstract once: <E extends NotifyEngineTypes.Event>(
+    event: E,
+    listener: (args: NotifyEngineTypes.EventArguments[E]) => void
+  ) => EventEmitter;
+
+  protected abstract off: <E extends NotifyEngineTypes.Event>(
+    event: E,
+    listener: (args: NotifyEngineTypes.EventArguments[E]) => void
+  ) => EventEmitter;
+
+  protected abstract emit: <E extends NotifyEngineTypes.Event>(
+    event: E,
+    args: NotifyEngineTypes.EventArguments[E]
+  ) => boolean;
 }

--- a/packages/notify-client/src/types/engine.ts
+++ b/packages/notify-client/src/types/engine.ts
@@ -93,8 +93,14 @@ export abstract class INotifyEngine {
 
   public abstract deleteNotifyMessage(params: { id: number }): void;
 
-  // ---------- Public Methods ------------------------------------------ //
-
+  public abstract getNotificationHistory(params: {
+    topic: string;
+    limit?: number;
+    startingAfter?: string;
+  }): Promise<{
+    notifications: NotifyClientTypes.NotifyMessage[];
+    hasMore: boolean;
+  }>;
   // query all active subscriptions
   public abstract getActiveSubscriptions(params?: {
     account: string;

--- a/packages/notify-client/src/types/engine.ts
+++ b/packages/notify-client/src/types/engine.ts
@@ -20,6 +20,21 @@ export declare namespace NotifyEngineTypes {
     payload: T;
     publishedAt: number;
   }
+
+  type EventResponseOrError<T> = (T & {error: null}) | {
+    error: string
+  }
+
+  type Event =
+    | "notify_get_notifications_response"
+
+  interface EventArguments {
+    notify_get_notifications_response: EventResponseOrError<{
+      notifications: NotifyClientTypes.NotifyMessage[];
+      hasMore: boolean;
+      hasMoreUnread: boolean;
+    }>;
+  }
 }
 
 export abstract class INotifyEngine {

--- a/packages/notify-client/src/types/engine.ts
+++ b/packages/notify-client/src/types/engine.ts
@@ -193,4 +193,11 @@ export abstract class INotifyEngine {
       | JsonRpcResult<JsonRpcTypes.Results["wc_notifyUpdate"]>
       | JsonRpcError
   ): Promise<void>;
+
+  protected abstract onNotifyGetNotificationsResponse(
+    topic: string,
+    payload:
+      | JsonRpcResult<JsonRpcTypes.Results["wc_notifyGetNotifications"]>
+      | JsonRpcError
+  ): Promise<void>;
 }

--- a/packages/notify-client/src/types/jsonrpc.ts
+++ b/packages/notify-client/src/types/jsonrpc.ts
@@ -5,7 +5,8 @@ export declare namespace JsonRpcTypes {
     | "wc_notifyDelete"
     | "wc_notifyWatchSubscription"
     | "wc_notifySubscriptionsChanged"
-    | "wc_notifyUpdate";
+    | "wc_notifyUpdate"
+    | "wc_notifyGetNotifications";
 
   // ---- JSON-RPC Requests -----------------------------
   export interface RequestParams {
@@ -27,6 +28,9 @@ export declare namespace JsonRpcTypes {
     wc_notifyUpdate: {
       updateAuth: string;
     };
+    wc_notifyGetNotifications: {
+      auth: string;
+    };
   }
 
   // ---- JSON-RPC Responses -----------------------------
@@ -46,6 +50,9 @@ export declare namespace JsonRpcTypes {
     };
     wc_notifyUpdate: {
       responseAuth: string;
+    };
+    wc_notifyGetNotifications: {
+      auth: string;
     };
   }
 }

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -466,9 +466,9 @@ describe("Notify", () => {
       });
     });
 
-describe.skipIf(!hasTestProjectSecret)("Message retrieval", () => {
+    describe.skipIf(!hasTestProjectSecret)("Message retrieval", () => {
       it("getNotificationHistory", async () => {
-	let totalMessages = 0;
+        let totalMessages = 0;
         await createNotifySubscription(wallet, account, onSign);
 
         expect(wallet.subscriptions.getAll().length).toEqual(1);
@@ -484,27 +484,27 @@ describe.skipIf(!hasTestProjectSecret)("Message retrieval", () => {
         await waitForEvent(() => Date.now() - now > 1_000);
 
         wallet.on("notify_message", () => {
-	  totalMessages++;
+          totalMessages++;
         });
 
-	for(let i = 0; i < 2; ++i) {
-	  await sendNotifyMessage(account, `${i}Test`);
-	}
+        for (let i = 0; i < 2; ++i) {
+          await sendNotifyMessage(account, `${i}Test`);
+        }
 
-	await waitForEvent(() => totalMessages === 2);
+        await waitForEvent(() => totalMessages === 2);
 
-	await wallet.messages.delete(testSub.topic, {
-	  code: -1,
-	  message: "Delete for testing"
-	});
+        await wallet.messages.delete(testSub.topic, {
+          code: -1,
+          message: "Delete for testing",
+        });
 
-	const history = await wallet.getNotificationHistory({
-	  topic: testSub.topic,
-	  limit: 2,
-	})
+        const history = await wallet.getNotificationHistory({
+          topic: testSub.topic,
+          limit: 2,
+        });
 
-	console.log({history: history.notifications})
-      })
+        console.log({ history: history.notifications });
+      });
     });
 
     describe("deleteSubscription", () => {

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -487,8 +487,9 @@ describe("Notify", () => {
           totalMessages++;
         });
 
-        for (let i = 0; i < 2; ++i) {
-          await sendNotifyMessage(account, `${i}Test`);
+	const notifications = [0,1].map(num => `${num}Test`)
+        for (const notification of notifications) {
+          await sendNotifyMessage(account, notification);
         }
 
         await waitForEvent(() => totalMessages === 2);
@@ -503,7 +504,9 @@ describe("Notify", () => {
           limit: 2,
         });
 
-        console.log({ history: history.notifications });
+	expect(history.notifications.map(n => n.body)).toEqual(notifications);
+
+	expect(history.hasMore).toEqual(false);
       });
     });
 

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -36,6 +36,8 @@ const hasTestProjectSecret =
 
 const projectId = process.env.TEST_PROJECT_ID;
 
+const runningLocally = Boolean(process.env.TEST_IS_LOCAL)
+
 describe("Notify", () => {
   let core: ICore;
   let wallet: INotifyClient;
@@ -625,7 +627,7 @@ describe("Notify", () => {
         expect(wallet2ReceivedChangedEvent).toEqual(true);
       });
 
-      it("handles multiple subscriptions", async () => {
+      it.skipIf(!runningLocally)("handles multiple subscriptions", async () => {
         const wallet1 = await NotifyClient.init({
           name: "testNotifyClient1",
           logger: "error",

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -538,45 +538,6 @@ describe("Notify", () => {
       });
     });
 
-    describe("deleteNotifyMessage", async () => {
-      it("deletes the notify message associated with the provided `id`", async () => {
-        await createNotifySubscription(wallet, account, onSign);
-        const [subscription] = wallet.subscriptions.getAll();
-        const { topic } = subscription;
-        const message = {
-          id: "test_id",
-          title: "Test Notify",
-          body: "This is a test notify notification",
-          icon: "xyz.png",
-          url: "https://walletconnect.com",
-        };
-
-        wallet.messages.set(topic, {
-          topic,
-          messages: {
-            "1685014464223153": {
-              id: 1685014464223153,
-              topic:
-                "a185fd51f0a9a4d1fb4fffb4129480a8779d6c8f549cbbac3a0cfefd8788cd5d",
-              message,
-              publishedAt: 1685014464322,
-            },
-          },
-        });
-
-        const messages = Object.values(wallet.messages.get(topic).messages);
-
-        expect(messages.length).toBe(1);
-
-        const targetMessageId = messages[0].id;
-        wallet.deleteNotifyMessage({ id: targetMessageId });
-
-        expect(Object.values(wallet.messages.get(topic).messages).length).toBe(
-          0
-        );
-      });
-    });
-
     describe("watchSubscriptions", () => {
       it("fires correct event update", async () => {
         let updateEvent: any = {};

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -487,7 +487,7 @@ describe("Notify", () => {
           totalMessages++;
         });
 
-	const notifications = [0,1].map(num => `${num}Test`)
+        const notifications = [0, 1].map((num) => `${num}Test`);
         for (const notification of notifications) {
           await sendNotifyMessage(account, notification);
         }
@@ -504,9 +504,9 @@ describe("Notify", () => {
           limit: 2,
         });
 
-	expect(history.notifications.map(n => n.body)).toEqual(notifications);
+        expect(history.notifications.map((n) => n.body)).toEqual(notifications);
 
-	expect(history.hasMore).toEqual(false);
+        expect(history.hasMore).toEqual(false);
       });
     });
 

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -466,60 +466,45 @@ describe("Notify", () => {
       });
     });
 
-    describe("getMessageHistory", async () => {
-      it("can get message history for a known notify topic", async () => {
+describe.skipIf(!hasTestProjectSecret)("Message retrieval", () => {
+      it("getNotificationHistory", async () => {
+	let totalMessages = 0;
         await createNotifySubscription(wallet, account, onSign);
-        const [subscription] = wallet.subscriptions.getAll();
-        const { topic } = subscription;
-        const message1 = {
-          id: "test_id_1",
-          title: "Test Notify 1",
-          body: "This is a test notify notification",
-          icon: "xyz.png",
-          url: "https://walletconnect.com",
-        };
-        const message2 = {
-          id: "test_id_2",
-          title: "Test Notify 2",
-          body: "This is a test notify notification",
-          icon: "xyz.png",
-          url: "https://walletconnect.com",
-        };
 
-        wallet.messages.set(topic, {
-          topic,
-          messages: {
-            "1685014464223153": {
-              id: 1685014464223153,
-              topic:
-                "a185fd51f0a9a4d1fb4fffb4129480a8779d6c8f549cbbac3a0cfefd8788cd5d",
-              message: message1,
-              publishedAt: 1685014464322,
-            },
-            "1685014464326223": {
-              id: 1685014464326223,
-              topic:
-                "a185fd51f0a9a4d1fb4fffb4129480a8779d6c8f549cbbac3a0cfefd8788cd5d",
-              message: message2,
-              publishedAt: 1685014464426,
-            },
-          },
+        expect(wallet.subscriptions.getAll().length).toEqual(1);
+
+        const testSub = wallet.subscriptions.getAll()[0];
+
+        expect(
+          Object.keys(wallet.messages.get(testSub.topic).messages).length
+        ).toEqual(0);
+
+        const now = Date.now();
+
+        await waitForEvent(() => Date.now() - now > 1_000);
+
+        wallet.on("notify_message", () => {
+	  totalMessages++;
         });
 
-        const messageHistory = wallet.getMessageHistory({ topic });
-        const sortedHistory = Object.values(messageHistory).sort(
-          (a, b) => a.publishedAt - b.publishedAt
-        );
+	for(let i = 0; i < 2; ++i) {
+	  await sendNotifyMessage(account, `${i}Test`);
+	}
 
-        expect(sortedHistory.length).toBe(2);
-        expect(sortedHistory[0].id).toBeDefined();
-        expect(sortedHistory[0].topic).toBeDefined();
-        expect(sortedHistory[0].publishedAt).toBeDefined();
-        expect(sortedHistory.map(({ message }) => message)).to.deep.equal([
-          message1,
-          message2,
-        ]);
-      });
+	await waitForEvent(() => totalMessages === 2);
+
+	await wallet.messages.delete(testSub.topic, {
+	  code: -1,
+	  message: "Delete for testing"
+	});
+
+	const history = await wallet.getNotificationHistory({
+	  topic: testSub.topic,
+	  limit: 2,
+	})
+
+	console.log({history: history.notifications})
+      })
     });
 
     describe("deleteSubscription", () => {

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -36,7 +36,7 @@ const hasTestProjectSecret =
 
 const projectId = process.env.TEST_PROJECT_ID;
 
-const runningLocally = Boolean(process.env.TEST_IS_LOCAL)
+const runningLocally = Boolean(process.env.TEST_IS_LOCAL);
 
 describe("Notify", () => {
   let core: ICore;


### PR DESCRIPTION
# Changes
- Implement `getNoticationHistory` per [spec](https://github.com/WalletConnect/walletconnect-specs/pull/183). 
- Resolves #89 
- Remove `getMessageHistory` and `deleteNotifyMessage`
- This is all working towards the #87 epic 

## To achieve this
- New event handlers were put in place in the engine, mimicking the ones in the client. `on`,`off`, `once`, etc. 
- These are in place to go against the current pub-sub architecture in place, to provide "blocking" functions that resolve once a response is given
- This is to achieve the spec which takes in params and returns the results in the same function
- This system will be reused by many other functions, including the refactored `subscribe` down the line. 

## Tested
Tested via new integration test that communicates with notify server

### How does this new flow work?
![image](https://github.com/WalletConnect/notify-client-js/assets/61278030/b62cf38c-f1e7-4bc0-9854-fb3006f15940)

