### PR TITLE
Fix/sent at mappiong

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7042,7 +7042,7 @@
     },
     "packages/notify-client": {
       "name": "@walletconnect/notify-client",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^1.7.3",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/notify-client",
   "description": "WalletConnect Notify Client",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/notify-client-js/",
   "license": "Apache-2.0",

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -839,20 +839,21 @@ export class NotifyEngine extends INotifyEngine {
             "notify_get_notifications_response"
           );
 
-	const mappedNotifications: NotifyClientTypes.NotifyMessage[] = claims.nfs.map(nf => ({
-	  body: nf.body,
-	  id: nf.id,
-	  sentAt: nf.sent_at,
-	  title: nf.title,
-	  url: nf.url,
-	  type: nf.type
-	}))
+        const mappedNotifications: NotifyClientTypes.NotifyMessage[] =
+          claims.nfs.map((nf) => ({
+            body: nf.body,
+            id: nf.id,
+            sentAt: nf.sent_at,
+            title: nf.title,
+            url: nf.url,
+            type: nf.type,
+          }));
 
         this.emit("notify_get_notifications_response", {
           hasMore: claims.mre ?? false,
           hasMoreUnread: claims.mur ?? false,
           error: null,
-          notifications: mappedNotifications
+          notifications: mappedNotifications,
         });
       } else if (isJsonRpcError(payload)) {
         this.client.logger.error(

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -839,11 +839,20 @@ export class NotifyEngine extends INotifyEngine {
             "notify_get_notifications_response"
           );
 
+	const mappedNotifications: NotifyClientTypes.NotifyMessage[] = claims.nfs.map(nf => ({
+	  body: nf.body,
+	  id: nf.id,
+	  sentAt: nf.sent_at,
+	  title: nf.title,
+	  url: nf.url,
+	  type: nf.type
+	}))
+
         this.emit("notify_get_notifications_response", {
           hasMore: claims.mre ?? false,
           hasMoreUnread: claims.mur ?? false,
           error: null,
-          notifications: claims.nfs,
+          notifications: mappedNotifications
         });
       } else if (isJsonRpcError(payload)) {
         this.client.logger.error(

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -105,6 +105,15 @@ export declare namespace NotifyClientTypes {
     expiry: number;
   }
 
+  interface NotifyServerMessage {
+    title: string;
+    sent_at: number;
+    body: string;
+    id: string;
+    url: string;
+    type?: string;
+  }
+
   interface NotifyMessage {
     title: string;
     sentAt: number;
@@ -217,7 +226,7 @@ export declare namespace NotifyClientTypes {
     aud: string; // did:key of client identity key
     mur: boolean; // more unread
     mre: boolean; // more pages
-    nfs: NotifyMessage[];
+    nfs: NotifyServerMessage[];
   }
 
   interface NotifyWatchSubscriptionsResponseClaims extends BaseJwtClaims {

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -508,6 +508,8 @@ describe("Notify", () => {
 
         expect(history.notifications.map((n) => n.body)).toEqual(notifications);
 
+	expect(history.notifications[0].sentAt).toBeTypeOf("number")
+
         expect(history.hasMore).toEqual(false);
       });
     });

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -508,7 +508,7 @@ describe("Notify", () => {
 
         expect(history.notifications.map((n) => n.body)).toEqual(notifications);
 
-	expect(history.notifications[0].sentAt).toBeTypeOf("number")
+        expect(history.notifications[0].sentAt).toBeTypeOf("number");
 
         expect(history.hasMore).toEqual(false);
       });


### PR DESCRIPTION
# Changes
Notify server sends `sentAt` as `sent_at`, requiring that we now map notifications coming from notify server to our own type in the client. 

- Added a mapping step to `getNotificationHistory`