### PR TITLE
chore: expose hasFinishedLoading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7042,7 +7042,7 @@
     },
     "packages/notify-client": {
       "name": "@walletconnect/notify-client",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^1.7.3",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/notify-client",
   "description": "WalletConnect Notify Client",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/notify-client-js/",
   "license": "Apache-2.0",

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -37,6 +37,7 @@ export class NotifyClient extends INotifyClient {
   public registrationData: INotifyClient["registrationData"];
   public identityKeys: INotifyClient["identityKeys"];
 
+
   static async init(opts: NotifyClientTypes.ClientOptions) {
     const client = new NotifyClient(opts);
     await client.initialize();
@@ -107,6 +108,10 @@ export class NotifyClient extends INotifyClient {
   }
 
   // ---------- Engine ----------------------------------------------- //
+
+  public hasFinishedInitialLoad: INotifyClient["hasFinishedInitialLoad"] = () => {
+    return this.engine.hasFinishedInitialLoad();
+  }
 
   public subscribe: INotifyClient["subscribe"] = async (params) => {
     try {

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -37,7 +37,6 @@ export class NotifyClient extends INotifyClient {
   public registrationData: INotifyClient["registrationData"];
   public identityKeys: INotifyClient["identityKeys"];
 
-
   static async init(opts: NotifyClientTypes.ClientOptions) {
     const client = new NotifyClient(opts);
     await client.initialize();
@@ -109,9 +108,10 @@ export class NotifyClient extends INotifyClient {
 
   // ---------- Engine ----------------------------------------------- //
 
-  public hasFinishedInitialLoad: INotifyClient["hasFinishedInitialLoad"] = () => {
-    return this.engine.hasFinishedInitialLoad();
-  }
+  public hasFinishedInitialLoad: INotifyClient["hasFinishedInitialLoad"] =
+    () => {
+      return this.engine.hasFinishedInitialLoad();
+    };
 
   public subscribe: INotifyClient["subscribe"] = async (params) => {
     try {

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -42,6 +42,8 @@ export class NotifyEngine extends INotifyEngine {
   public name = "notifyEngine";
   private initialized = false;
 
+  private finishedInitialLoad = false;
+
   private didDocMap = new Map<string, NotifyClientTypes.NotifyDidDocument>();
 
   constructor(client: INotifyEngine["client"]) {
@@ -60,6 +62,11 @@ export class NotifyEngine extends INotifyEngine {
       this.initialized = true;
     }
   };
+
+  public hasFinishedInitialLoad() {
+    return this.finishedInitialLoad
+  }
+
 
   // ---------- Public --------------------------------------- //
 
@@ -888,6 +895,8 @@ export class NotifyEngine extends INotifyEngine {
           id: payload.id,
           subscriptions,
         });
+
+	this.finishedInitialLoad = true;
 
         this.client.emit("notify_subscriptions_changed", {
           id: payload.id,

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -896,6 +896,9 @@ export class NotifyEngine extends INotifyEngine {
           subscriptions,
         });
 
+	// Flag is used for consumers of the SDK to know if notify client finished loading
+	// since the event below might be emitted before `init` resolves.
+	
         this.finishedInitialLoad = true;
 
         this.client.emit("notify_subscriptions_changed", {
@@ -906,6 +909,9 @@ export class NotifyEngine extends INotifyEngine {
           },
         });
       } else if (isJsonRpcError(payload)) {
+	// Even if there was an error, loading is technically complete
+        this.finishedInitialLoad = true;
+
         this.client.logger.error({
           event: "onNotifyWatchSubscriptionsResponse",
           topic,

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -63,12 +63,11 @@ export class NotifyEngine extends INotifyEngine {
     }
   };
 
-  public hasFinishedInitialLoad() {
+  // ---------- Public --------------------------------------- //
+
+  public hasFinishedInitialLoad: INotifyEngine["hasFinishedInitialLoad"] = () => {
     return this.finishedInitialLoad
   }
-
-
-  // ---------- Public --------------------------------------- //
 
   public prepareRegistration: INotifyEngine["prepareRegistration"] = async ({
     account,

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -906,7 +906,7 @@ export class NotifyEngine extends INotifyEngine {
           },
         });
       } else if (isJsonRpcError(payload)) {
-	// Even if there was an error, loading is technically complete
+        // Even if there was an error, loading is technically complete
         this.finishedInitialLoad = true;
 
         this.client.logger.error({

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -896,9 +896,6 @@ export class NotifyEngine extends INotifyEngine {
           subscriptions,
         });
 
-	// Flag is used for consumers of the SDK to know if notify client finished loading
-	// since the event below might be emitted before `init` resolves.
-	
         this.finishedInitialLoad = true;
 
         this.client.emit("notify_subscriptions_changed", {

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -65,9 +65,10 @@ export class NotifyEngine extends INotifyEngine {
 
   // ---------- Public --------------------------------------- //
 
-  public hasFinishedInitialLoad: INotifyEngine["hasFinishedInitialLoad"] = () => {
-    return this.finishedInitialLoad
-  }
+  public hasFinishedInitialLoad: INotifyEngine["hasFinishedInitialLoad"] =
+    () => {
+      return this.finishedInitialLoad;
+    };
 
   public prepareRegistration: INotifyEngine["prepareRegistration"] = async ({
     account,
@@ -895,7 +896,7 @@ export class NotifyEngine extends INotifyEngine {
           subscriptions,
         });
 
-	this.finishedInitialLoad = true;
+        this.finishedInitialLoad = true;
 
         this.client.emit("notify_subscriptions_changed", {
           id: payload.id,

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -288,7 +288,6 @@ export abstract class INotifyClient {
   public abstract readonly keyserverUrl: string;
   public abstract readonly notifyServerUrl: string;
 
-
   public abstract core: ICore;
   public abstract events: EventEmitter;
   public abstract logger: Logger;

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -288,6 +288,7 @@ export abstract class INotifyClient {
   public abstract readonly keyserverUrl: string;
   public abstract readonly notifyServerUrl: string;
 
+
   public abstract core: ICore;
   public abstract events: EventEmitter;
   public abstract logger: Logger;
@@ -340,6 +341,7 @@ export abstract class INotifyClient {
   public abstract getNotificationHistory: INotifyEngine["getNotificationHistory"];
   public abstract getActiveSubscriptions: INotifyEngine["getActiveSubscriptions"];
   public abstract deleteSubscription: INotifyEngine["deleteSubscription"];
+  public abstract hasFinishedInitialLoad: INotifyEngine["hasFinishedInitialLoad"];
 
   // ---------- Event Handlers ------------------------------------------------------- //
 

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -340,6 +340,9 @@ export abstract class INotifyClient {
   public abstract getNotificationHistory: INotifyEngine["getNotificationHistory"];
   public abstract getActiveSubscriptions: INotifyEngine["getActiveSubscriptions"];
   public abstract deleteSubscription: INotifyEngine["deleteSubscription"];
+
+  // Flag is used for consumers of the SDK to know if notify client finished loading
+  // since the event below might be emitted before `init` resolves.
   public abstract hasFinishedInitialLoad: INotifyEngine["hasFinishedInitialLoad"];
 
   // ---------- Event Handlers ------------------------------------------------------- //

--- a/packages/notify-client/src/types/engine.ts
+++ b/packages/notify-client/src/types/engine.ts
@@ -46,6 +46,8 @@ export abstract class INotifyEngine {
 
   // ---------- Public Methods ------------------------------------------ //
 
+  public abstract hasFinishedInitialLoad(): boolean
+
   public abstract prepareRegistration(params: {
     account: string;
     domain: string;

--- a/packages/notify-client/src/types/engine.ts
+++ b/packages/notify-client/src/types/engine.ts
@@ -46,7 +46,7 @@ export abstract class INotifyEngine {
 
   // ---------- Public Methods ------------------------------------------ //
 
-  public abstract hasFinishedInitialLoad(): boolean
+  public abstract hasFinishedInitialLoad(): boolean;
 
   public abstract prepareRegistration(params: {
     account: string;

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -591,7 +591,7 @@ describe("Notify", () => {
         await waitForEvent(() => gotNotifyUpdateResponse);
         await waitForEvent(() => updatedCount === 3);
 
-	expect(wallet.hasFinishedInitialLoad()).toEqual(true)
+        expect(wallet.hasFinishedInitialLoad()).toEqual(true);
 
         expect(updateEvent.topic).toBe(subscriptions[0].topic);
       });

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -591,6 +591,8 @@ describe("Notify", () => {
         await waitForEvent(() => gotNotifyUpdateResponse);
         await waitForEvent(() => updatedCount === 3);
 
+	expect(wallet.hasFinishedInitialLoad()).toEqual(true)
+
         expect(updateEvent.topic).toBe(subscriptions[0].topic);
       });
 


### PR DESCRIPTION
# Changes
- bump version to `0.16.2` (patch)
- add new function `hasFinishedLoading`: Checks if `watchSubscriptions` has succeeded and finalized

# Why
The response for watch subscriptions is sometimes received *before* notify client's `init` function has resolved. 

Consumers of this SDK should be able to tell when notify client has fetched all subscriptions to show appropriate loading states.