### PR TITLE
chore: be more vigilante against inconsistent state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7042,7 +7042,7 @@
     },
     "packages/notify-client": {
       "name": "@walletconnect/notify-client",
-      "version": "0.16.2",
+      "version": "0.16.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^1.7.3",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/notify-client",
   "description": "WalletConnect Notify Client",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/notify-client-js/",
   "license": "Apache-2.0",

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -163,9 +163,6 @@ export class NotifyEngine extends INotifyEngine {
 
           // If account was the last to be watched
           if (watchedAccount.lastWatched) {
-            this.client.logger.info(
-              `[Notify] unregister > account ${watchedAccount.account} was last to be watched. Unmarking as last watched`
-            );
             // Remove last watched flag, to prevent watching on next init.
             await this.client.watchedAccounts.update(watchedAccount.account, {
               lastWatched: false,

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -135,12 +135,15 @@ export class NotifyEngine extends INotifyEngine {
 
   public unregister: INotifyEngine["unregister"] = async ({ account }) => {
     try {
-      // Get information about watching subscriptions of account
 
       if (!(await this.client.identityKeys.hasIdentity({ account }))) {
         return;
       }
 
+      // If user has watched their subscriptions before, stop watching.
+      // We can not assume that every registerd user has a watchedAccount
+      // due to the fact that the stores for watchedAccounts and identityKeys
+      // are entirely separate.
       if (this.client.watchedAccounts.keys.includes(account)) {
         const watchedAccount = this.client.watchedAccounts.get(account);
 
@@ -185,6 +188,8 @@ export class NotifyEngine extends INotifyEngine {
       // unregister from identity server
       await this.client.identityKeys.unregisterIdentity({ account });
 
+      // If user has registration data, clear it to prevent false
+      // data regarding staleness of identity
       if (this.client.registrationData.keys.includes(account)) {
         this.client.registrationData.delete(account, {
           code: -1,

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -135,7 +135,6 @@ export class NotifyEngine extends INotifyEngine {
 
   public unregister: INotifyEngine["unregister"] = async ({ account }) => {
     try {
-
       if (!(await this.client.identityKeys.hasIdentity({ account }))) {
         return;
       }

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -140,7 +140,7 @@ export class NotifyEngine extends INotifyEngine {
       }
 
       // If user has watched their subscriptions before, stop watching.
-      // We can not assume that every registerd user has a watchedAccount
+      // We can not assume that every registered user has a watchedAccount
       // due to the fact that the stores for watchedAccounts and identityKeys
       // are entirely separate.
       if (this.client.watchedAccounts.keys.includes(account)) {


### PR DESCRIPTION
Fixes https://github.com/WalletConnect/web3inbox/issues/357

`unregister` was not prepared for inconsistent state, namely if `watchedAccounts` was not populated. Furthermore, it never cleaned up `registrationData`. 

The reason this was discovered and that this fix was issued was because users on web3inbox that had mismatched state for any reason (Eg refreshing during registration process) had state that was completely unrecoverable because they could not unregister.

What this does is:
- Guard statement getting the watchedAccount to check if it exists first
- Cleanup `registrationData` store for that account