### PR TITLE
chore: add more vigilant checking to resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7269,7 +7269,7 @@
     },
     "packages/notify-client": {
       "name": "@walletconnect/notify-client",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^1.7.3",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/notify-client",
   "description": "WalletConnect Notify Client",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/notify-client-js/",
   "license": "Apache-2.0",

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -295,7 +295,7 @@ export class NotifyEngine extends INotifyEngine {
       const listener = (
         args: NotifyClientTypes.EventArguments["notify_subscription"]
       ) => {
-        if (args.topic !== subscribeTopic) {
+        if (args.topic !== responseTopic) {
           return;
         }
         this.client.off("notify_subscription", listener);

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -295,7 +295,7 @@ export class NotifyEngine extends INotifyEngine {
       const listener = (
         args: NotifyClientTypes.EventArguments["notify_subscription"]
       ) => {
-        if (args.topic === subscribeTopic) {
+        if (args.topic !== subscribeTopic) {
           return;
         }
         this.client.off("notify_subscription", listener);

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -16,7 +16,7 @@ import {
   isJsonRpcResult,
 } from "@walletconnect/jsonrpc-utils";
 import { FIVE_MINUTES } from "@walletconnect/time";
-import { EngineTypes, JsonRpcRecord, RelayerTypes } from "@walletconnect/types";
+import { JsonRpcRecord, RelayerTypes } from "@walletconnect/types";
 import {
   TYPE_1,
   deriveSymKey,

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -34,7 +34,12 @@ import {
   NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS,
   NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN,
 } from "../constants";
-import { INotifyEngine, JsonRpcTypes, NotifyClientTypes, NotifyEngineTypes } from "../types";
+import {
+  INotifyEngine,
+  JsonRpcTypes,
+  NotifyClientTypes,
+  NotifyEngineTypes,
+} from "../types";
 import { getCaip10FromDidPkh } from "../utils/address";
 import { getDappUrl } from "../utils/formats";
 
@@ -287,19 +292,21 @@ export class NotifyEngine extends INotifyEngine {
     );
 
     return new Promise<boolean>((resolve) => {
-      const listener = (args: NotifyClientTypes.EventArguments['notify_subscription']) => {
-	if(args.topic === subscribeTopic)  {
-	  return
-	}
-	this.client.off("notify_subscription", listener);
+      const listener = (
+        args: NotifyClientTypes.EventArguments["notify_subscription"]
+      ) => {
+        if (args.topic === subscribeTopic) {
+          return;
+        }
+        this.client.off("notify_subscription", listener);
         if (args.params.error) {
-	  resolve(false)
+          resolve(false);
         } else {
           resolve(true);
         }
-      }
+      };
 
-      this.client.on("notify_subscription", listener)
+      this.client.on("notify_subscription", listener);
 
       // SPEC: Wallet sends wc_notifySubscribe request (type 1 envelope) on subscribe topic with subscriptionAuth
       this.sendRequest<"wc_notifySubscribe">(
@@ -357,17 +364,19 @@ export class NotifyEngine extends INotifyEngine {
     );
 
     return new Promise<boolean>((resolve, reject) => {
-      const listener = (args: NotifyClientTypes.EventArguments['notify_update']) => {
-	if(args.topic === topic)  {
-	  return
-	}
-	this.client.off("notify_update", listener);
+      const listener = (
+        args: NotifyClientTypes.EventArguments["notify_update"]
+      ) => {
+        if (args.topic === topic) {
+          return;
+        }
+        this.client.off("notify_update", listener);
         if (args.params.error) {
           reject(args.params.error);
         } else {
           resolve(true);
         }
-      }
+      };
 
       this.client.on("notify_update", listener);
 
@@ -433,19 +442,21 @@ export class NotifyEngine extends INotifyEngine {
       );
 
       return new Promise((resolve, reject) => {
-	const listener = (args: NotifyEngineTypes.EventArguments["notify_get_notifications_response"]) => {
-	  if(args.topic !== topic) {
-	    return;
-	  }
+        const listener = (
+          args: NotifyEngineTypes.EventArguments["notify_get_notifications_response"]
+        ) => {
+          if (args.topic !== topic) {
+            return;
+          }
 
-	  this.off("notify_get_notifications_response", listener)
+          this.off("notify_get_notifications_response", listener);
 
           if (args.error === null) {
             resolve(args);
           } else {
             reject(new Error(args.error));
           }
-	}
+        };
 
         this.on("notify_get_notifications_response", listener);
 
@@ -511,19 +522,21 @@ export class NotifyEngine extends INotifyEngine {
     });
 
     return new Promise<void>((resolve, reject) => {
-      const listener = (args: NotifyClientTypes.EventArguments['notify_delete']) => {
-	if(args.topic === topic)  {
-	  return
-	}
-	this.client.off("notify_delete", listener);
+      const listener = (
+        args: NotifyClientTypes.EventArguments["notify_delete"]
+      ) => {
+        if (args.topic === topic) {
+          return;
+        }
+        this.client.off("notify_delete", listener);
         if (args.params.error) {
           reject(args.params.error);
         } else {
           resolve();
         }
-      }
+      };
 
-      this.client.on("notify_delete", listener)
+      this.client.on("notify_delete", listener);
 
       this.sendRequest(topic, "wc_notifyDelete", { deleteAuth }).then(() => {
         this.client.logger.info(
@@ -968,7 +981,7 @@ export class NotifyEngine extends INotifyEngine {
           }));
 
         this.emit("notify_get_notifications_response", {
-	  topic,
+          topic,
           hasMore: claims.mre ?? false,
           hasMoreUnread: claims.mur ?? false,
           error: null,
@@ -982,7 +995,7 @@ export class NotifyEngine extends INotifyEngine {
         );
 
         this.emit("notify_get_notifications_response", {
-	  topic,
+          topic,
           error: payload.error.message,
         });
       }

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -367,10 +367,11 @@ export class NotifyEngine extends INotifyEngine {
       const listener = (
         args: NotifyClientTypes.EventArguments["notify_update"]
       ) => {
-        if (args.topic === topic) {
+        if (args.topic !== topic) {
           return;
         }
         this.client.off("notify_update", listener);
+
         if (args.params.error) {
           reject(args.params.error);
         } else {
@@ -525,7 +526,7 @@ export class NotifyEngine extends INotifyEngine {
       const listener = (
         args: NotifyClientTypes.EventArguments["notify_delete"]
       ) => {
-        if (args.topic === topic) {
+        if (args.topic !== topic) {
           return;
         }
         this.client.off("notify_delete", listener);

--- a/packages/notify-client/src/types/engine.ts
+++ b/packages/notify-client/src/types/engine.ts
@@ -26,10 +26,11 @@ export declare namespace NotifyEngineTypes {
   }
 
   type EventResponseOrError<T> =
+    { topic: string } & (
     | (T & { error: null })
     | {
         error: string;
-      };
+    });
 
   type Event = "notify_get_notifications_response";
 

--- a/packages/notify-client/src/types/engine.ts
+++ b/packages/notify-client/src/types/engine.ts
@@ -25,12 +25,12 @@ export declare namespace NotifyEngineTypes {
     publishedAt: number;
   }
 
-  type EventResponseOrError<T> =
-    { topic: string } & (
+  type EventResponseOrError<T> = { topic: string } & (
     | (T & { error: null })
     | {
         error: string;
-    });
+      }
+  );
 
   type Event = "notify_get_notifications_response";
 

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -13,7 +13,7 @@ import {
   NotifyClientTypes,
 } from "../src/";
 import { waitForEvent } from "./helpers/async";
-import { testDappMetadata } from "./helpers/mocks";
+import { gmHackersMetadata, testDappMetadata } from "./helpers/mocks";
 import { createNotifySubscription, sendNotifyMessage } from "./helpers/notify";
 import { disconnectSocket } from "./helpers/ws";
 import axios from "axios";
@@ -842,6 +842,97 @@ describe("Notify", () => {
 
         expect(Object.keys(wallet3.getActiveSubscriptions()).length).toEqual(0);
       });
+    });
+
+    describe("Blocking functions", () => {
+      it("Subscribe only resolves once a subscription succeeded and is stored", async () => {
+        const preparedRegistration = await wallet.prepareRegistration({
+          account,
+          domain: testDappMetadata.appDomain,
+          allApps: true,
+        });
+
+        await wallet.register({
+          registerParams: preparedRegistration.registerParams,
+          signature: await onSign(preparedRegistration.message),
+        });
+
+	await wallet.subscribe({appDomain: testDappMetadata.appDomain, account})
+
+	expect(wallet.subscriptions.length).toEqual(1)
+	expect(wallet.subscriptions.getAll()[0].metadata.appDomain).toEqual(testDappMetadata.appDomain)
+      });
+
+      it.skipIf(!hasTestProjectSecret)("Only resolves when topic accurate response is issued", async () => {
+        const preparedRegistration = await wallet.prepareRegistration({
+          account,
+          domain: testDappMetadata.appDomain,
+          allApps: true,
+        });
+
+        await wallet.register({
+          registerParams: preparedRegistration.registerParams,
+          signature: await onSign(preparedRegistration.message),
+        });
+
+	await wallet.subscribe({appDomain: testDappMetadata.appDomain, account})
+	
+	expect(wallet.subscriptions.length).toEqual(1)
+	expect(wallet.subscriptions.getAll()[0].metadata.appDomain).toEqual(testDappMetadata.appDomain)
+
+	const app1Topic = wallet.subscriptions.getAll()[0].topic
+
+	let gotMessage = false;
+
+	// send messages to app1
+        await sendNotifyMessage(account, "Test1");
+
+	console.log(">>>>>>>>>> sent message")
+
+	wallet.on("notify_message", () => {
+	  gotMessage = true;
+	})
+
+	await waitForEvent(() => gotMessage)
+
+	console.log(">>>>>>>>>> got message")
+
+	const notifs1 = wallet.getNotificationHistory({topic: app1Topic, limit: 5});
+
+	// close transport to prevent getting a real response from the relay
+	await wallet.core.relayer.transportClose()
+
+	const emptyNotif = {
+	    body: '',
+	    id: '',
+	    sentAt: Date.now(),
+	    title: '',
+	    type: '',
+	    url: ''
+	  }
+
+
+	wallet.engine['emit']("notify_get_notifications_response", {
+	  topic: "wrong_topic",
+	  error: null,
+	  hasMore: false,
+	  hasMoreUnread: false,
+	  notifications: []
+	})
+
+	wallet.engine['emit']("notify_get_notifications_response", {
+	  topic: app1Topic,
+	  error: null,
+	  hasMore: false,
+	  hasMoreUnread: false,
+	  notifications: [emptyNotif, emptyNotif]
+	})
+
+	expect(notifs1).resolves.toSatisfy((resolved: any) => {
+	  console.log("Resolved is!", resolved)
+	  return resolved.notifications.length === 2
+	})
+      })
     });
 
     describe.skipIf(!hasTestProjectSecret)("Message Deduping", () => {


### PR DESCRIPTION
- Resolves #100 
- Only resolve blocking functions when the same topic is sent in the response as the request
- Add unit tests for blocking functions 