### PR TITLE
Fix/identity key init

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7269,7 +7269,7 @@
     },
     "packages/notify-client": {
       "name": "@walletconnect/notify-client",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^1.7.3",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/notify-client",
   "description": "WalletConnect Notify Client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/notify-client-js/",
   "license": "Apache-2.0",

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -94,7 +94,7 @@ export class NotifyClient extends INotifyClient {
     );
 
     this.identityKeys =
-      opts.identityKeys ?? new IdentityKeys(this.core, this.keyserverUrl);
+      opts.identityKeys ?? new IdentityKeys(this.core, opts.projectId, this.keyserverUrl);
     this.engine = new NotifyEngine(this);
   }
 

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -93,8 +93,14 @@ export class NotifyClient extends INotifyClient {
       ({ account }: { account: string }) => account
     );
 
+    const projectId = opts.projectId ?? this.core.projectId;
+
+    if(!projectId) {
+      throw new Error("Project ID is required for notify client")
+    }
+
     this.identityKeys =
-      opts.identityKeys ?? new IdentityKeys(this.core, opts.projectId, this.keyserverUrl);
+      opts.identityKeys ?? new IdentityKeys(this.core, projectId, this.keyserverUrl);
     this.engine = new NotifyEngine(this);
   }
 

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -95,12 +95,13 @@ export class NotifyClient extends INotifyClient {
 
     const projectId = opts.projectId ?? this.core.projectId;
 
-    if(!projectId) {
-      throw new Error("Project ID is required for notify client")
+    if (!projectId) {
+      throw new Error("Project ID is required for notify client");
     }
 
     this.identityKeys =
-      opts.identityKeys ?? new IdentityKeys(this.core, projectId, this.keyserverUrl);
+      opts.identityKeys ??
+      new IdentityKeys(this.core, projectId, this.keyserverUrl);
     this.engine = new NotifyEngine(this);
   }
 


### PR DESCRIPTION
- Pass projectId to identity kewys
- Throw error if projectId is not passed

This fixes an error with eip1271 validation. This was not previously caught as eip1271 support was tested against web3inbox which injects identity keys provider