### PR TITLE
chore: forward notify message to notify notification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7269,7 +7269,7 @@
     },
     "packages/notify-client": {
       "name": "@walletconnect/notify-client",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/ed25519": "^1.7.3",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@walletconnect/notify-client",
   "description": "WalletConnect Notify Client",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "author": "WalletConnect, Inc. <walletconnect.com>",
   "homepage": "https://github.com/walletconnect/notify-client-js/",
   "license": "Apache-2.0",

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -903,6 +903,11 @@ export class NotifyEngine extends INotifyEngine {
         topic,
         params: { message: messageClaims.msg },
       });
+      this.client.emit("notify_notification", {
+        id: payload.id,
+        topic,
+        params: { notification: messageClaims.msg },
+      });
     };
 
   protected onNotifyMessageResponse: INotifyEngine["onNotifyMessageResponse"] =

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -17,6 +17,7 @@ export declare namespace NotifyClientTypes {
   type Event =
     | "notify_subscription"
     | "notify_message"
+    | "notify_notification"
     | "notify_delete"
     | "notify_update"
     | "notify_subscriptions_changed";
@@ -31,6 +32,10 @@ export declare namespace NotifyClientTypes {
   };
 
   type NotifyMessageRequestEventArgs = {
+    message: NotifyClientTypes.NotifyNotification;
+  };
+
+  type NotifyNotificationRequestEventArgs = {
     message: NotifyClientTypes.NotifyNotification;
   };
 
@@ -49,6 +54,7 @@ export declare namespace NotifyClientTypes {
       }
     >;
     notify_message: BaseEventArgs<NotifyMessageRequestEventArgs>;
+    notify_notification: BaseEventArgs<NotifyNotificationRequestEventArgs>;
     notify_delete: BaseEventArgs<NotifyResponseEventArgs>;
     notify_update: BaseEventArgs<
       NotifyResponseEventArgs & {

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -36,7 +36,7 @@ export declare namespace NotifyClientTypes {
   };
 
   type NotifyNotificationRequestEventArgs = {
-    message: NotifyClientTypes.NotifyNotification;
+    notification: NotifyClientTypes.NotifyNotification;
   };
 
   type NotifyDeleteRequestEventArgs = { id: number; topic: string };

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -261,10 +261,18 @@ describe("Notify", () => {
           let gotNotifyMessageResponse = false;
           let notifyMessageEvent: any;
 
+	  let gotNotifyNotificationResponse = false;
+          let notifyNotificationEvent: any;
+
           wallet.once("notify_message", (event) => {
             console.log("notify_message", event);
             gotNotifyMessageResponse = true;
             notifyMessageEvent = event;
+          });
+
+          wallet.once("notify_notification", (event) => {
+            gotNotifyNotificationResponse = true;
+	    notifyNotificationEvent = event;
           });
 
           const sendResponse = await sendNotifyMessage(account, "Test");
@@ -272,8 +280,10 @@ describe("Notify", () => {
           expect(sendResponse.status).toBe(200);
 
           await waitForEvent(() => gotNotifyMessageResponse);
+          await waitForEvent(() => gotNotifyNotificationResponse);
 
           expect(notifyMessageEvent.params.message.body).toBe("Test");
+          expect(notifyNotificationEvent.params.notification.body).toBe("Test");
         });
 
         it("reads the dapp's did.json from memory after the initial fetch", async () => {

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -261,7 +261,7 @@ describe("Notify", () => {
           let gotNotifyMessageResponse = false;
           let notifyMessageEvent: any;
 
-	  let gotNotifyNotificationResponse = false;
+          let gotNotifyNotificationResponse = false;
           let notifyNotificationEvent: any;
 
           wallet.once("notify_message", (event) => {
@@ -272,7 +272,7 @@ describe("Notify", () => {
 
           wallet.once("notify_notification", (event) => {
             gotNotifyNotificationResponse = true;
-	    notifyNotificationEvent = event;
+            notifyNotificationEvent = event;
           });
 
           const sendResponse = await sendNotifyMessage(account, "Test");


### PR DESCRIPTION
- Resolves #108 
- Now emits `notify_notification`  wherever `notify_message` is emitted.
- Not removing `notify_message` for the forseeable future as it would break backwards compatibility and will require a `major` version bump
- update unit test of `notify_message` to show changes