### PR TITLE
Feat/sdk flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       ],
       "devDependencies": {
         "@rollup/plugin-commonjs": "22.0.1",
+        "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-node-resolve": "13.3.0",
         "@types/node": "18.6.1",
         "@types/pino": "6.3.3",
@@ -1393,6 +1394,54 @@
       "peerDependencies": {
         "rollup": "^1.20.0 || ^2.0.0"
       }
+    },
+    "node_modules/@rollup/plugin-json": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
+      "integrity": "sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-json/node_modules/@rollup/pluginutils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+      "integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-json/node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
     },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "13.3.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "22.0.1",
+    "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "13.3.0",
     "@types/node": "18.6.1",
     "@types/pino": "6.3.3",

--- a/packages/notify-client/package.json
+++ b/packages/notify-client/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "clean": "rm -rf dist",
-    "build:pre": "npm run clean",
+    "build:pre": "npm run clean && sh ./scripts/update_sdk_versions.sh",
     "build:types": "tsc",
     "build:source": "rollup --config rollup.config.js",
     "build": "npm run build:pre; npm run build:source; npm run build:types",

--- a/packages/notify-client/scripts/update_sdk_versions.sh
+++ b/packages/notify-client/scripts/update_sdk_versions.sh
@@ -2,7 +2,6 @@
 
 notify_ver=$(grep "version" package.json | head -n1 | awk -F'"' '{print $4;}')
 
-
 version_line="export const NOTIFY_SDK_VERSION = "\"$notify_ver\"";"
 
 echo "$version_line" > src/constants/sdk_version.ts

--- a/packages/notify-client/scripts/update_sdk_versions.sh
+++ b/packages/notify-client/scripts/update_sdk_versions.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+notify_ver=$(grep "version" package.json | head -n1 | awk -F'"' '{print $4;}')
+
+
+version_line="export const NOTIFY_SDK_VERSION = "\"$notify_ver\"";"
+
+echo "$version_line" > src/constants/sdk_version.ts

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -1,4 +1,7 @@
 import { Core, Store } from "@walletconnect/core";
+import { version as coreVersion } from "@walletconnect/core/package.json";
+// @ts-ignore
+import { version as notifyVersion } from "../package.json";
 import {
   generateChildLogger,
   getDefaultLoggerOptions,
@@ -24,6 +27,7 @@ export class NotifyClient extends INotifyClient {
   public readonly version = NOTIFY_CLIENT_VERSION;
   public readonly name: INotifyClient["name"] =
     NOTIFY_WALLET_CLIENT_DEFAULT_NAME;
+  public readonly sdkVersionMap: INotifyClient["sdkVersionMap"];
   public readonly keyserverUrl: INotifyClient["keyserverUrl"];
   public readonly notifyServerUrl: INotifyClient["notifyServerUrl"];
 
@@ -102,6 +106,13 @@ export class NotifyClient extends INotifyClient {
     this.identityKeys =
       opts.identityKeys ??
       new IdentityKeys(this.core, projectId, this.keyserverUrl);
+
+    this.sdkVersionMap = {
+      "@walletconnect/core": coreVersion,
+      "@walletconnect/notify-client": notifyVersion,
+      ...opts.sdkVersionMapEntries,
+    };
+
     this.engine = new NotifyEngine(this);
   }
 

--- a/packages/notify-client/src/client.ts
+++ b/packages/notify-client/src/client.ts
@@ -1,7 +1,5 @@
 import { Core, Store } from "@walletconnect/core";
 import { version as coreVersion } from "@walletconnect/core/package.json";
-// @ts-ignore
-import { version as notifyVersion } from "../package.json";
 import {
   generateChildLogger,
   getDefaultLoggerOptions,
@@ -21,6 +19,7 @@ import {
 } from "./constants";
 import { NotifyEngine } from "./controllers";
 import { INotifyClient, NotifyClientTypes } from "./types";
+import { NOTIFY_SDK_VERSION } from "./constants/sdk_version";
 
 export class NotifyClient extends INotifyClient {
   public readonly protocol = NOTIFY_CLIENT_PROTOCOL;
@@ -109,7 +108,7 @@ export class NotifyClient extends INotifyClient {
 
     this.sdkVersionMap = {
       "@walletconnect/core": coreVersion,
-      "@walletconnect/notify-client": notifyVersion,
+      "@walletconnect/notify-client": NOTIFY_SDK_VERSION,
       ...opts.sdkVersionMapEntries,
     };
 

--- a/packages/notify-client/src/constants/clients.ts
+++ b/packages/notify-client/src/constants/clients.ts
@@ -10,3 +10,5 @@ export const DEFAULT_NOTIFY_SERVER_URL = "https://notify.walletconnect.com";
 export const DEFAULT_EXPLORER_API_URL =
   "https://explorer-api.walletconnect.com/w3i/v1";
 export const DEFAULT_KEYSERVER_URL = "https://keys.walletconnect.com";
+
+export const NOTIFY_CLIENT_PACKAGE_MANAGER = "npm";

--- a/packages/notify-client/src/constants/sdk_version.ts
+++ b/packages/notify-client/src/constants/sdk_version.ts
@@ -1,0 +1,1 @@
+export const NOTIFY_SDK_VERSION = "1.2.2";

--- a/packages/notify-client/src/controllers/engine.ts
+++ b/packages/notify-client/src/controllers/engine.ts
@@ -33,6 +33,7 @@ import {
   JWT_SCP_SEPARATOR,
   NOTIFY_AUTHORIZATION_STATEMENT_ALL_DOMAINS,
   NOTIFY_AUTHORIZATION_STATEMENT_THIS_DOMAIN,
+  NOTIFY_CLIENT_PACKAGE_MANAGER,
 } from "../constants";
 import {
   INotifyEngine,
@@ -253,6 +254,7 @@ export class NotifyEngine extends INotifyEngine {
       notifyConfig?.notificationTypes
         .map((type) => type.id)
         .join(JWT_SCP_SEPARATOR) ?? "";
+
     const payload: NotifyClientTypes.SubscriptionJWTClaims = {
       iat: issuedAt,
       exp: expiry,
@@ -263,6 +265,13 @@ export class NotifyEngine extends INotifyEngine {
       scp,
       act: "notify_subscription",
       app: `${DID_WEB_PREFIX}${appDomain}`,
+      mjv: "1",
+      sdk: {
+        packageManager: NOTIFY_CLIENT_PACKAGE_MANAGER,
+        packages: {
+          ...this.client.sdkVersionMap,
+        },
+      },
     };
 
     this.client.logger.info(
@@ -434,6 +443,13 @@ export class NotifyEngine extends INotifyEngine {
           app: `${DID_WEB_PREFIX}${subscription.metadata.appDomain}`,
           lmt: limit ?? 50,
           urf: unreadFirst ?? true,
+          mjv: "1",
+          sdk: {
+            packageManager: NOTIFY_CLIENT_PACKAGE_MANAGER,
+            packages: {
+              ...this.client.sdkVersionMap,
+            },
+          },
         };
 
       const auth = await this.client.identityKeys.generateIdAuth(
@@ -1275,6 +1291,13 @@ export class NotifyEngine extends INotifyEngine {
       ksu: this.client.keyserverUrl,
       sub: composeDidPkh(accountId),
       app: allApps ? null : `did:web:${appDomain}`,
+      mjv: "1",
+      sdk: {
+        packageManager: NOTIFY_CLIENT_PACKAGE_MANAGER,
+        packages: {
+          ...this.client.sdkVersionMap,
+        },
+      },
     };
 
     const generatedAuth = await this.client.identityKeys.generateIdAuth(
@@ -1490,6 +1513,13 @@ export class NotifyEngine extends INotifyEngine {
         sub: composeDidPkh(subscription.account),
         app: `${DID_WEB_PREFIX}${subscription.metadata.appDomain}`,
         ksu: this.client.keyserverUrl,
+        mjv: "1",
+        sdk: {
+          packageManager: NOTIFY_CLIENT_PACKAGE_MANAGER,
+          packages: {
+            ...this.client.sdkVersionMap,
+          },
+        },
       };
 
       const responseAuth = await this.client.identityKeys.generateIdAuth(
@@ -1531,6 +1561,13 @@ export class NotifyEngine extends INotifyEngine {
         sub: composeDidPkh(subscription.account),
         ksu: this.client.keyserverUrl,
         app: `${DID_WEB_PREFIX}${subscription.metadata.appDomain}`,
+        mjv: "1",
+        sdk: {
+          packageManager: NOTIFY_CLIENT_PACKAGE_MANAGER,
+          packages: {
+            ...this.client.sdkVersionMap,
+          },
+        },
       };
 
       const deleteAuth = await this.client.identityKeys.generateIdAuth(
@@ -1578,6 +1615,13 @@ export class NotifyEngine extends INotifyEngine {
         app: `${DID_WEB_PREFIX}${subscription.metadata.appDomain}`,
         ksu: this.client.keyserverUrl,
         scp: scope.join(JWT_SCP_SEPARATOR),
+        mjv: "1",
+        sdk: {
+          packageManager: NOTIFY_CLIENT_PACKAGE_MANAGER,
+          packages: {
+            ...this.client.sdkVersionMap,
+          },
+        },
       };
 
       const updateAuth = await this.client.identityKeys.generateIdAuth(
@@ -1902,6 +1946,13 @@ export class NotifyEngine extends INotifyEngine {
         sub: composeDidPkh(subscription.account),
         iat: issuedAt,
         exp: expiry,
+        mjv: "1",
+        sdk: {
+          packageManager: NOTIFY_CLIENT_PACKAGE_MANAGER,
+          packages: {
+            ...this.client.sdkVersionMap,
+          },
+        },
       };
 
     const auth = await this.client.identityKeys.generateIdAuth(

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -69,12 +69,18 @@ export declare namespace NotifyClientTypes {
     iat: number; // issued at
     exp: number; // expiry
     ksu: string; // key server url
+    mjv: string; // major version on the protocol level
+    sdk: {
+      packageManager: "npm" | "kotlin" | "swift";
+      packages: Record<string, string>;
+    }; // sdk version
   }
 
   interface ClientOptions extends CoreTypes.Options {
     core?: ICore;
     keyserverUrl?: string;
     identityKeys?: IdentityKeys;
+    sdkVersionMapEntries?: Record<string, string>;
   }
 
   interface Metadata {
@@ -320,6 +326,7 @@ export abstract class INotifyClient {
   public abstract readonly name: string;
   public abstract readonly keyserverUrl: string;
   public abstract readonly notifyServerUrl: string;
+  public abstract readonly sdkVersionMap: Record<string, string>;
 
   public abstract core: ICore;
   public abstract events: EventEmitter;

--- a/packages/notify-client/src/types/client.ts
+++ b/packages/notify-client/src/types/client.ts
@@ -71,7 +71,7 @@ export declare namespace NotifyClientTypes {
     ksu: string; // key server url
     mjv: string; // major version on the protocol level
     sdk: {
-      packageManager: "npm" | "kotlin" | "swift";
+      packageManager: "npm";
       packages: Record<string, string>;
     }; // sdk version
   }

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -358,9 +358,9 @@ describe("Notify", () => {
 
         // Ensure all scopes have been disabled in the updated subscription.
         expect(
-          Object.values(Object.values(wallet.getActiveSubscriptions())[0].scope).find(
-            (scp) => scp.id === testScopeId
-          )?.enabled
+          Object.values(
+            Object.values(wallet.getActiveSubscriptions())[0].scope
+          ).find((scp) => scp.id === testScopeId)?.enabled
         ).toBe(true);
       });
     });

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -333,9 +333,6 @@ describe("Notify", () => {
         await createNotifySubscription(wallet, account, onSign);
 
         let gotNotifyUpdateResponse = false;
-        let gotNotifySubscriptionsChangedRequest = false;
-        let lastChangedSubscriptions: NotifyClientTypes.NotifySubscription[] =
-          [];
 
         wallet.once("notify_update", () => {
           gotNotifyUpdateResponse = true;
@@ -357,16 +354,11 @@ describe("Notify", () => {
 
         await waitForEvent(() => gotNotifyUpdateResponse);
 
-        await waitForEvent(() => gotNotifySubscriptionsChangedRequest);
-
         expect(gotNotifyUpdateResponse).toBe(true);
-        expect(wallet.subscriptions.keys[0]).toBe(
-          lastChangedSubscriptions[0].topic
-        );
 
         // Ensure all scopes have been disabled in the updated subscription.
         expect(
-          Object.values(lastChangedSubscriptions[0].scope).find(
+          Object.values(Object.values(wallet.getActiveSubscriptions())[0].scope).find(
             (scp) => scp.id === testScopeId
           )?.enabled
         ).toBe(true);

--- a/packages/notify-client/test/clients.spec.ts
+++ b/packages/notify-client/test/clients.spec.ts
@@ -185,19 +185,11 @@ describe("Notify", () => {
 
         expect(responsePreUnregister.status).toEqual(200);
 
-        let gotSub = false;
-        newClient.on("notify_subscriptions_changed", (ev) => {
-          gotSub = ev.params.subscriptions
-            .map((sub) => sub.metadata.appDomain)
-            .includes(testDappMetadata.appDomain);
-        });
-
         await newClient.subscribe({
           account: newAccount,
           appDomain: testDappMetadata.appDomain,
         });
 
-        await waitForEvent(() => gotSub);
         expect(newClient.subscriptions.getAll().length).toEqual(1);
 
         const subTopic = newClient.subscriptions.getAll()[0].topic;
@@ -330,7 +322,7 @@ describe("Notify", () => {
           // We have to account for the initial calls that happened during watchSubscriptions on init
           // Also have to account for the jwt update that happens when creating a subscription
           expect(axiosSpy).toHaveBeenCalledTimes(
-            INITIAL_CALLS_FETCH_ACCOUNT + 2
+            INITIAL_CALLS_FETCH_ACCOUNT + 1
           );
         });
       }
@@ -347,11 +339,6 @@ describe("Notify", () => {
 
         wallet.once("notify_update", () => {
           gotNotifyUpdateResponse = true;
-        });
-        wallet.on("notify_subscriptions_changed", (event) => {
-          console.log("notify_subscriptions_changed", event);
-          gotNotifySubscriptionsChangedRequest = true;
-          lastChangedSubscriptions = event.params.subscriptions;
         });
 
         const subscriptions = wallet.subscriptions.getAll();

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ import esbuild from "rollup-plugin-esbuild";
 import nodePolyfills from "rollup-plugin-polyfill-node";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json"
 
 const input = "./src/index.ts";
 const plugins = [
@@ -10,6 +11,7 @@ const plugins = [
     browser: true,
   }),
   commonjs(),
+  json(),
   nodePolyfills(),
   esbuild({
     minify: true,


### PR DESCRIPTION
- Resolves #112 
- Sets `mjv` to `1` (Technically breaking change but the docs are written as if it's always been `mjv=1`)
- Set `platform` to `npm` for `sdk` map
- Add script that gets the current version of notify json from `package.json` file and adds it to a typescript file
- Add `@rollup/plugin-json` to read the versions of sub packages (I.E `@walletconnect/core`
- Adapt tests to `mjv=1`